### PR TITLE
daily-detailページ作成　 #27

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -51,7 +51,7 @@ const routes: Routes = [
       },
 
       {
-        path: 'update',
+        path: 'update/:id',
         loadChildren: () =>
           import('./update/update.module').then((m) => m.UpdateModule),
         canLoad: [AuthGuard],

--- a/src/app/daily-detail/daily-detail.component.html
+++ b/src/app/daily-detail/daily-detail.component.html
@@ -16,9 +16,9 @@
     <div class="border"></div>
     <div class="result__nutrial">
       <p class="result__cal">カロリー：XXX kcal</p>
-      <p class="result__">タンパク質：XXX kcal</p>
-      <p class="result__">資質：XXX kcal</p>
-      <p class="result__">糖質：XXX kcal</p>
+      <p>タンパク質：XXX kcal</p>
+      <p>資質：XXX kcal</p>
+      <p>糖質：XXX kcal</p>
     </div>
     <div class="result__memo" *ngIf="dailyInfo.dailyMemo; else noMemo">
       <div class="border"></div>

--- a/src/app/daily-detail/daily-detail.component.html
+++ b/src/app/daily-detail/daily-detail.component.html
@@ -1,18 +1,33 @@
 <div class="dailyInfo" *ngIf="dailyInfo$ | async as dailyInfo; else deafult">
-  <p class="daily-card__weight">体重：{{ dailyInfo.currentWeight }} kg</p>
-  <p class="daily-card__fat">体脂肪率：{{ dailyInfo.currentFat }} %</p>
-  <button
-    [routerLink]="['/update']"
-    [queryParams]="{ id: dailyInfo.dailyId }"
-    mat-mini-fab
-    color="primary"
-  >
-    ＋
-  </button>
-  <p class="daily-card__cal">カロリー：XXX kcal</p>
-  <p class="daily-card__">タンパク質：XXX kcal</p>
-  <p class="daily-card__">資質：XXX kcal</p>
-  <p class="daily-card__">糖質：XXX kcal</p>
+  <div class="result">
+    <div class="result__record">
+      <div class="result__body">
+        <p class="result__weight">体重：{{ dailyInfo.currentWeight }} kg</p>
+        <p class="result__fat">体脂肪率：{{ dailyInfo.currentFat }} %</p>
+      </div>
+      <button
+        [routerLink]="['/update', dailyInfo.dailyId]"
+        mat-icon-button
+        color="primary"
+      >
+        <mat-icon>edit</mat-icon>
+      </button>
+    </div>
+    <div class="border"></div>
+    <div class="result__nutrial">
+      <p class="result__cal">カロリー：XXX kcal</p>
+      <p class="result__">タンパク質：XXX kcal</p>
+      <p class="result__">資質：XXX kcal</p>
+      <p class="result__">糖質：XXX kcal</p>
+    </div>
+    <div class="result__memo" *ngIf="dailyInfo.dailyMemo; else noMemo">
+      <div class="border"></div>
+      <p class="result__memo-title">1日のメモ</p>
+      <p class="result__memo-textarea">{{ dailyInfo.dailyMemo }}</p>
+    </div>
+    <ng-template class="result__memo--noMemo" #noMemo> </ng-template>
+  </div>
+
   <p>パイチャート</p>
 
   <div class="meal">

--- a/src/app/daily-detail/daily-detail.component.scss
+++ b/src/app/daily-detail/daily-detail.component.scss
@@ -1,3 +1,35 @@
+.result {
+  background: #fff;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  &__record {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  &__memo {
+    margin-top: 0;
+    width: 100%;
+    &--noMemo {
+      margin: 0;
+    }
+  }
+  &__memo-title {
+    margin-bottom: 0;
+  }
+  &__memo-textarea {
+    margin: 0;
+    padding: 8px;
+    border: solid 1px rgba(0, 0, 0, 0.2);
+    border-radius: 5px;
+    white-space: nowrap;
+    overflow: hidden;
+    white-space: initial;
+    word-break: break-all;
+    height: 100px;
+  }
+}
+
 .meal {
   border: 1px solid;
   background: white;

--- a/src/app/daily-detail/daily-detail.module.ts
+++ b/src/app/daily-detail/daily-detail.module.ts
@@ -4,9 +4,15 @@ import { CommonModule } from '@angular/common';
 import { DailyDetailRoutingModule } from './daily-detail-routing.module';
 import { DailyDetailComponent } from './daily-detail.component';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [DailyDetailComponent],
-  imports: [CommonModule, DailyDetailRoutingModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    DailyDetailRoutingModule,
+    MatButtonModule,
+    MatIconModule,
+  ],
 })
 export class DailyDetailModule {}

--- a/src/app/edit/edit/edit.component.html
+++ b/src/app/edit/edit/edit.component.html
@@ -3,11 +3,16 @@
     <div class="form-body__body">
       <mat-form-field class="form-body__weight">
         <mat-label>体重</mat-label>
-        <input formControlName="currentWeight" type="number" matInput />
+        <input
+          formControlName="currentWeight"
+          type="number"
+          matInput
+          required
+        />
       </mat-form-field>
       <mat-form-field class="form-body__fat">
         <mat-label>体脂肪</mat-label>
-        <input formControlName="currentFat" type="number" matInput />
+        <input formControlName="currentFat" type="number" matInput required />
       </mat-form-field>
     </div>
 
@@ -21,7 +26,7 @@
     </mat-form-field>
   </div>
 
-  <button (click)="CreateSubmit()" mat-stroked-button color="primary">
+  <button (click)="createSubmit()" mat-stroked-button color="primary">
     登録する
   </button>
 </form>

--- a/src/app/edit/edit/edit.component.html
+++ b/src/app/edit/edit/edit.component.html
@@ -1,23 +1,28 @@
-<div class="container">
-  <h1>今日の情報入力画面</h1>
+<form [formGroup]="form">
+  <div class="form-body">
+    <div class="form-body__body">
+      <mat-form-field class="form-body__weight">
+        <mat-label>体重</mat-label>
+        <input formControlName="currentWeight" type="number" matInput />
+      </mat-form-field>
+      <mat-form-field class="form-body__fat">
+        <mat-label>体脂肪</mat-label>
+        <input formControlName="currentFat" type="number" matInput />
+      </mat-form-field>
+    </div>
 
-  <form [formGroup]="form" (ngSubmit)="CreateSubmit()">
-    <mat-form-field>
-      <mat-label>体重</mat-label>
-      <input formControlName="currentWeight" type="number" matInput />
+    <mat-form-field class="form-body__memo">
+      <mat-label>1日メモ</mat-label>
+      <textarea
+        class="form-body__memo-textarea"
+        formControlName="dailyMemo"
+        matInput
+      ></textarea>
     </mat-form-field>
-    <mat-form-field>
-      <mat-label>体脂肪</mat-label>
-      <input formControlName="currentFat" type="number" matInput />
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>食べ物</mat-label>
-      <input formControlName="dailyMemo" type="text" matInput />
-    </mat-form-field>
+  </div>
 
-    <button [disabled]="form.invalid" mat-stroked-button color="primary">
-      登録する
-    </button>
-  </form>
-  <button routerLink="/top" mat-stroked-button color="primary">戻る</button>
-</div>
+  <button (click)="CreateSubmit()" mat-stroked-button color="primary">
+    登録する
+  </button>
+</form>
+<button (click)="back()" mat-stroked-button color="primary">戻る</button>

--- a/src/app/edit/edit/edit.component.scss
+++ b/src/app/edit/edit/edit.component.scss
@@ -1,0 +1,30 @@
+.form-body {
+  margin-top: 48px;
+  margin-bottom: 24px;
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  background: #ffff;
+  &__body {
+    margin-bottom: 40px;
+  }
+  &__weight {
+    width: 50%;
+  }
+  &__fat {
+    width: 50%;
+  }
+  &__form-body__memo {
+    width: 100%;
+  }
+  &__memo-textarea {
+    height: 100px;
+  }
+}
+
+button {
+  display: block;
+  margin: 0 auto;
+  margin-bottom: 16px;
+  width: 25%;
+}

--- a/src/app/edit/edit/edit.component.ts
+++ b/src/app/edit/edit/edit.component.ts
@@ -30,7 +30,7 @@ export class EditComponent implements OnInit {
     return this.datepipe.transform(d, 'yy.MM.dd(E)');
   }
 
-  CreateSubmit() {
+  createSubmit() {
     const formData = this.form.value;
     this.dailyInfoService.createDailyInfo({
       authorId: this.authService.uid,

--- a/src/app/edit/edit/edit.component.ts
+++ b/src/app/edit/edit/edit.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { DailyInfoService } from 'src/app/services/daily-info.service';
 import { AuthService } from 'src/app/services/auth.service';
-import { DatePipe } from '@angular/common';
+import { DatePipe, Location } from '@angular/common';
 
 @Component({
   selector: 'app-edit',
@@ -20,7 +20,8 @@ export class EditComponent implements OnInit {
     private fb: FormBuilder,
     private dailyInfoService: DailyInfoService,
     private authService: AuthService,
-    private datepipe: DatePipe
+    private datepipe: DatePipe,
+    private location: Location
   ) {}
 
   ngOnInit(): void {}
@@ -38,5 +39,8 @@ export class EditComponent implements OnInit {
       currentFat: formData.currentFat,
       dailyMemo: formData.dailyMemo,
     });
+  }
+  back() {
+    this.location.back();
   }
 }

--- a/src/app/services/daily-info.service.ts
+++ b/src/app/services/daily-info.service.ts
@@ -67,18 +67,19 @@ export class DailyInfoService {
       );
   }
 
-  upadateDailyInfo(dailyInfo: any): Promise<void> {
-    console.log(dailyInfo.id);
+  updateDailyInfo(
+    dailyInfo: Omit<DailyInfo, 'date' | 'breakfast' | 'lunch' | 'dener'>
+  ): Promise<void> {
+    console.log(dailyInfo.authorId);
     return this.db
-      .doc(`dailyInfos/${dailyInfo.id}`)
+      .doc(`users/${dailyInfo.authorId}/dailyInfos/${dailyInfo.dailyId}`)
       .set(dailyInfo, {
         merge: true,
       })
       .then(() => {
-        this.snackBar.open('変更しました', null, {
+        this.snackBar.open('更新しました', null, {
           duration: 2000,
         });
-        this.router.navigateByUrl('');
       });
   }
 }

--- a/src/app/top/detail/detail.component.html
+++ b/src/app/top/detail/detail.component.html
@@ -26,10 +26,10 @@
           <mat-card-actions>
             <button
               [routerLink]="['/daily-detail', dailyInfo.dailyId]"
-              mat-fab
+              mat-icon-button
               color="primary"
             >
-              ＋
+              <mat-icon>edit</mat-icon>
             </button>
           </mat-card-actions>
         </div>

--- a/src/app/top/top.module.ts
+++ b/src/app/top/top.module.ts
@@ -6,6 +6,7 @@ import { TopComponent } from './top/top.component';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
 
 import { FullCalendarModule } from '@fullcalendar/angular';
 import { DetailComponent } from './detail/detail.component';
@@ -18,6 +19,7 @@ import { DetailComponent } from './detail/detail.component';
     TopRoutingModule,
     MatButtonModule,
     MatCardModule,
+    MatIconModule,
     FullCalendarModule,
   ],
   providers: [DatePipe],

--- a/src/app/update/update/update.component.html
+++ b/src/app/update/update/update.component.html
@@ -1,23 +1,34 @@
-<div class="container">
-  <h1>今日の情報入力画面</h1>
+<form [formGroup]="form">
+  <div class="form-body">
+    <div class="form-body__body">
+      <mat-form-field class="form-body__weight">
+        <mat-label>体重</mat-label>
+        <input formControlName="currentWeight" type="number" matInput />
+      </mat-form-field>
+      <mat-form-field class="form-body__fat">
+        <mat-label>体脂肪</mat-label>
+        <input formControlName="currentFat" type="number" matInput />
+      </mat-form-field>
+    </div>
 
-  <form [formGroup]="form">
-    <mat-form-field>
-      <mat-label>体重</mat-label>
-      <input formControlName="weight" type="number"  matInput />
+    <mat-form-field class="form-body__memo">
+      <mat-label>1日メモ</mat-label>
+      <textarea
+        class="form-body__memo-textarea"
+        formControlName="dailyMemo"
+        matInput
+      ></textarea>
     </mat-form-field>
-    <mat-form-field>
-      <mat-label>体脂肪</mat-label>
-      <input formControlName="fat" type="number" matInput />
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>食べ物</mat-label>
-      <input formControlName="totalCal" type="number" matInput />
-    </mat-form-field>
+  </div>
 
-    <button (click)="updateSubmit()" [disabled]="form.invalid" mat-stroked-button color="primary">
-      更新
-    </button>
-  </form>
-  <button [routerLink]="['']" mat-stroked-button color="primary">戻る</button>
-</div>
+  <button
+    (click)="updateSubmit()"
+    (click)="back()"
+    [disabled]="form.invalid"
+    mat-stroked-button
+    color="primary"
+  >
+    更新
+  </button>
+</form>
+<button (click)="back()" mat-stroked-button color="primary">戻る</button>

--- a/src/app/update/update/update.component.scss
+++ b/src/app/update/update/update.component.scss
@@ -1,0 +1,30 @@
+.form-body {
+  margin-top: 48px;
+  margin-bottom: 24px;
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  background: #ffff;
+  &__body {
+    margin-bottom: 40px;
+  }
+  &__weight {
+    width: 50%;
+  }
+  &__fat {
+    width: 50%;
+  }
+  &__form-body__memo {
+    width: 100%;
+  }
+  &__memo-textarea {
+    height: 100px;
+  }
+}
+
+button {
+  display: block;
+  margin: 0 auto;
+  margin-bottom: 16px;
+  width: 25%;
+}

--- a/src/app/update/update/update.component.ts
+++ b/src/app/update/update/update.component.ts
@@ -1,50 +1,77 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { DailyInfoService } from 'src/app/services/daily-info.service';
 import { ActivatedRoute } from '@angular/router';
 
 import { switchMap, take } from 'rxjs/operators';
+import { AuthService } from 'src/app/services/auth.service';
+import { Observable } from 'rxjs';
+import { DailyInfo } from 'src/app/interfaces/daily-info';
+import { Location } from '@angular/common';
 @Component({
   selector: 'app-update',
   templateUrl: './update.component.html',
   styleUrls: ['./update.component.scss'],
 })
 export class UpdateComponent implements OnInit {
-  id: string;
+  @Input() dailyInfo: DailyInfo;
+  dailyId: string;
+  dailyInfo$: Observable<DailyInfo>;
 
   form = this.fb.group({
-    weight: ['', [Validators.required]],
-    fat: ['', [Validators.required]],
-    totalCal: ['', [Validators.required]],
+    currentWeight: ['', [Validators.required]],
+    currentFat: ['', [Validators.required]],
+    dailyMemo: [''],
   });
 
   constructor(
     private fb: FormBuilder,
     private dailyInfoService: DailyInfoService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private authService: AuthService,
+    private location: Location
   ) {
-    this.route.queryParamMap.subscribe((params) => {
-      this.id = params.get('id');
-
-      this.dailyInfoService.getDailyInfo(this.id).subscribe((user) => {
-        if (user) {
-          this.form.patchValue(user);
-          console.log('wataru');
-        } else {
-          console.log('error');
-        }
-      });
+    this.route.paramMap.subscribe((params) => {
+      this.dailyId = params.get('id');
+      this.dailyInfoService
+        .getDailyInfo(this.authService.uid, this.dailyId)
+        .subscribe((dailyInfo) => {
+          if (dailyInfo) {
+            this.form.patchValue(dailyInfo);
+            console.log('wataru');
+          } else {
+            console.log('error');
+          }
+        });
     });
+    // this.route.queryParamMap.subscribe((params) => {
+    //   const id = params.get('id');
+
+    //   this.dailyInfoService
+    //     .getDailyInfo(this.authService.uid, id)
+    //     .subscribe((user) => {
+    //       if (user) {
+    //         this.form.patchValue(user);
+    //         console.log('wataru');
+    //       } else {
+    //         console.log('error');
+    //       }
+    //     });
+    // });
   }
   ngOnInit() {}
 
   updateSubmit() {
     const formData = this.form.value;
-    this.dailyInfoService.upadateDailyInfo({
-      weight: formData.weight,
-      fat: formData.fat,
-      totalCal: formData.totalCal,
-      id: this.id,
+    this.dailyInfoService.updateDailyInfo({
+      dailyId: this.dailyId,
+      currentWeight: formData.currentWeight,
+      currentFat: formData.currentFat,
+      dailyMemo: formData.dailyMemo,
+      authorId: this.authService.uid,
     });
+  }
+  back() {
+    this.location.back();
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -14,7 +14,8 @@ body {
 }
 .border {
   margin-top: 0;
-  border-top: 1px solid rgba($color: #000000, $alpha: 0.7);
+  border-top: 1px solid #000;
+  opacity: 0.2;
 }
 
 .meal__card {


### PR DESCRIPTION
1日の詳細ページ（daily-detail）ページおよび付随するページ（edit,update）作成しました。
ご確認お願いします。

## Detail
- daily-detailスタイル調整
- daillyInfo-serviceのcreate,update機能修正、firestore保存場所変更
- update,editスタイル調整
- 1日のメモ機能追加

## Image
![画面収録 2020-05-22 16 07 59](https://user-images.githubusercontent.com/63537174/82641184-e7debf00-9c46-11ea-8753-8101deb0fefb.gif)

fix #27 