### PR TITLE
エディターリスト画面作成　#29

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -51,7 +51,7 @@ const routes: Routes = [
       },
 
       {
-        path: 'update/:id',
+        path: 'update/:date',
         loadChildren: () =>
           import('./update/update.module').then((m) => m.UpdateModule),
         canLoad: [AuthGuard],
@@ -67,7 +67,16 @@ const routes: Routes = [
         canActivate: [AuthGuard],
       },
       {
-        path: 'editor-breakfast/:id',
+        path: 'editor-list',
+        loadChildren: () =>
+          import('./editor-list/editor-list.module').then(
+            (m) => m.EditorListModule
+          ),
+        canLoad: [AuthGuard],
+        canActivate: [AuthGuard],
+      },
+      {
+        path: 'editor-breakfast/:date',
         loadChildren: () =>
           import('./editor-breakfast/editor-breakfast.module').then(
             (m) => m.EditorBreakfastModule

--- a/src/app/daily-detail/daily-detail.component.html
+++ b/src/app/daily-detail/daily-detail.component.html
@@ -6,7 +6,7 @@
         <p class="result__fat">体脂肪率：{{ dailyInfo.currentFat }} %</p>
       </div>
       <button
-        [routerLink]="['/update', dailyInfo.dailyId]"
+        [routerLink]="['/update', dailyInfo.date]"
         mat-icon-button
         color="primary"
       >

--- a/src/app/editor-list/editor-list-routing.module.ts
+++ b/src/app/editor-list/editor-list-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { EditorListComponent } from './editor-list/editor-list.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: EditorListComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class EditorListRoutingModule {}

--- a/src/app/editor-list/editor-list.module.ts
+++ b/src/app/editor-list/editor-list.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { EditorListRoutingModule } from './editor-list-routing.module';
+import { EditorListComponent } from './editor-list/editor-list.component';
+
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+
+@NgModule({
+  declarations: [EditorListComponent],
+  imports: [
+    CommonModule,
+    EditorListRoutingModule,
+    MatCardModule,
+    MatIconModule,
+  ],
+})
+export class EditorListModule {}

--- a/src/app/editor-list/editor-list/editor-list.component.html
+++ b/src/app/editor-list/editor-list/editor-list.component.html
@@ -1,0 +1,51 @@
+<div class="container" *ngIf="dailyInfo$ | async as dailyInfo; else deafult">
+  <div class="card">
+    <mat-card
+      class="card__content"
+      [routerLink]="['/editor-breakfast', dailyInfo.date]"
+      >朝食
+      <div class="spacer"></div>
+      <mat-icon aria-hidden="false">arrow_forward_ios</mat-icon></mat-card
+    >
+  </div>
+  <div class="card">
+    <mat-card
+      class="card__content"
+      [routerLink]="['/editor-breakfast', dailyInfo.date]"
+      >昼食
+      <div class="spacer"></div>
+      <mat-icon aria-hidden="false">arrow_forward_ios</mat-icon></mat-card
+    >
+  </div>
+  <div class="card">
+    <mat-card
+      class="card__content"
+      [routerLink]="['/editor-breakfast', dailyInfo.date]"
+      >夕食
+      <div class="spacer"></div>
+      <mat-icon aria-hidden="false">arrow_forward_ios</mat-icon></mat-card
+    >
+  </div>
+  <div class="card">
+    <mat-card class="card__content" [routerLink]="['/update', dailyInfo.date]"
+      >体重・体脂肪率
+      <div class="spacer"></div>
+      <mat-icon aria-hidden="false">arrow_forward_ios</mat-icon></mat-card
+    >
+  </div>
+  <div class="card">
+    <mat-card class="card__content" [routerLink]="['/update', dailyInfo.date]"
+      >体型写真を撮る
+      <div class="spacer"></div>
+      <mat-icon aria-hidden="false">arrow_forward_ios</mat-icon></mat-card
+    >
+  </div>
+  <div class="card">
+    <mat-card class="card__content" [routerLink]="['/update', dailyInfo.date]"
+      >メモ
+      <div class="spacer"></div>
+      <mat-icon aria-hidden="false">arrow_forward_ios</mat-icon></mat-card
+    >
+  </div>
+</div>
+<ng-template #deafult>ページは存在しません</ng-template>

--- a/src/app/editor-list/editor-list/editor-list.component.scss
+++ b/src/app/editor-list/editor-list/editor-list.component.scss
@@ -1,0 +1,10 @@
+.card {
+  margin: 32px 0;
+
+  &__content {
+    display: flex;
+    justify-content: space-between;
+    cursor: pointer;
+    margin-bottom: 16px;
+  }
+}

--- a/src/app/editor-list/editor-list/editor-list.component.spec.ts
+++ b/src/app/editor-list/editor-list/editor-list.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditorListComponent } from './editor-list.component';
+
+describe('EditorListComponent', () => {
+  let component: EditorListComponent;
+  let fixture: ComponentFixture<EditorListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditorListComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditorListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/editor-list/editor-list/editor-list.component.ts
+++ b/src/app/editor-list/editor-list/editor-list.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { AuthService } from 'src/app/services/auth.service';
+import { Observable } from 'rxjs';
+import { DailyInfo } from 'src/app/interfaces/daily-info';
+import { DailyInfoService } from 'src/app/services/daily-info.service';
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'app-editor-list',
+  templateUrl: './editor-list.component.html',
+  styleUrls: ['./editor-list.component.scss'],
+})
+export class EditorListComponent implements OnInit {
+  date: string = this.getDate();
+  dailyInfo$: Observable<DailyInfo> = this.dailyInfoService.getDailyInfo(
+    this.authService.uid,
+    this.date
+  );
+  constructor(
+    private dailyInfoService: DailyInfoService,
+    private authService: AuthService,
+    private datepipe: DatePipe
+  ) {}
+  getDate() {
+    const d = new Date();
+    return this.datepipe.transform(d, 'yy.MM.dd(E)');
+  }
+  ngOnInit(): void {}
+}

--- a/src/app/interfaces/daily-info.ts
+++ b/src/app/interfaces/daily-info.ts
@@ -7,7 +7,7 @@ export interface DailyInfo {
   currentFat: number;
   breakfast: number;
   lunch: number;
-  dener: number;
+  denner: number;
   dailyMemo: string;
   authorId: string;
 }

--- a/src/app/services/daily-info.service.ts
+++ b/src/app/services/daily-info.service.ts
@@ -18,24 +18,6 @@ export class DailyInfoService {
     private router: Router
   ) {}
 
-  createDailyInfo(
-    dailyInfo: Omit<DailyInfo, 'dailyId' | 'breakfast' | 'lunch' | 'dener'>
-  ): Promise<void> {
-    const dailyId = this.db.createId();
-    return this.db
-      .doc(`users/${dailyInfo.authorId}/dailyInfos/${dailyId}`)
-      .set({
-        dailyId,
-        ...dailyInfo,
-      })
-      .then(() => {
-        this.snackBar.open('登録しました', null, {
-          duration: 2000,
-        });
-        this.router.navigateByUrl('');
-      });
-  }
-
   getDailyInfos(authorId: string): Observable<DailyInfo[]> {
     return this.db
       .collection<DailyInfo>(`users/${authorId}/dailyInfos`, (ref) =>
@@ -43,9 +25,9 @@ export class DailyInfoService {
       )
       .valueChanges();
   }
-  getDailyInfo(authorId: string, id: string): Observable<DailyInfo> {
+  getDailyInfo(authorId: string, date: string): Observable<DailyInfo> {
     return this.db
-      .doc<DailyInfo>(`users/${authorId}/dailyInfos/${id}`)
+      .doc<DailyInfo>(`users/${authorId}/dailyInfos/${date}`)
       .valueChanges();
   }
 
@@ -67,12 +49,44 @@ export class DailyInfoService {
       );
   }
 
-  updateDailyInfo(
-    dailyInfo: Omit<DailyInfo, 'date' | 'breakfast' | 'lunch' | 'dener'>
+  createDailyInfo(
+    dailyInfo: Omit<
+      DailyInfo,
+      | 'dailyId'
+      | 'currentWeight'
+      | 'currentFat'
+      | 'breakfast'
+      | 'lunch'
+      | 'denner'
+      | 'dailyMemo'
+    >
+  ) {
+    this.getDailyInfo(dailyInfo.authorId, dailyInfo.date).subscribe((isdoc) => {
+      if (!isdoc) {
+        console.log('empty');
+        const dailyId = this.db.createId();
+        return this.db
+          .doc(`users/${dailyInfo.authorId}/dailyInfos/${dailyInfo.date}`)
+          .set({
+            dailyId,
+            ...dailyInfo,
+          })
+          .then(() => {
+            this.router.navigateByUrl('editor-list');
+          });
+      } else {
+        console.log('isdoc');
+        this.router.navigateByUrl('editor-list');
+      }
+    });
+  }
+
+  updateDailyInfoBody(
+    dailyInfo: Omit<DailyInfo, 'dailyId' | 'breakfast' | 'lunch' | 'denner'>
   ): Promise<void> {
     console.log(dailyInfo.authorId);
     return this.db
-      .doc(`users/${dailyInfo.authorId}/dailyInfos/${dailyInfo.dailyId}`)
+      .doc(`users/${dailyInfo.authorId}/dailyInfos/${dailyInfo.date}`)
       .set(dailyInfo, {
         merge: true,
       })

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -6,7 +6,7 @@
     <button mat-icon-button>
       <mat-icon>show_chart</mat-icon>
     </button>
-    <button mat-mini-fab color="primary" [routerLink]="['/edit']">
+    <button mat-mini-fab color="primary" (click)="createDailyInfo()">
       ＋
     </button>
     <button mat-icon-button>

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,4 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { DailyInfoService } from '../services/daily-info.service';
+import { AuthService } from '../services/auth.service';
+import { DailyInfo } from '../interfaces/daily-info';
 
 @Component({
   selector: 'app-toolbar',
@@ -6,7 +10,23 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./toolbar.component.scss'],
 })
 export class ToolbarComponent implements OnInit {
-  constructor() {}
+  @Input() dailyInfo: DailyInfo;
+  date: string = this.getDate();
+  constructor(
+    private dailyInfoService: DailyInfoService,
+    private authService: AuthService,
+    private datepipe: DatePipe
+  ) {}
+  getDate() {
+    const d = new Date();
+    return this.datepipe.transform(d, 'yy.MM.dd(E)');
+  }
+  createDailyInfo() {
+    this.dailyInfoService.createDailyInfo({
+      authorId: this.authService.uid,
+      date: this.date,
+    });
+  }
 
   ngOnInit(): void {}
 }

--- a/src/app/top/detail/detail.component.html
+++ b/src/app/top/detail/detail.component.html
@@ -2,7 +2,7 @@
   今日は登録済み
 </ng-container>
 <ng-template #deafult
-  ><button routerLink="/edit" mat-stroked-button color="primary">
+  ><button (click)="createDailyInfo()" mat-stroked-button color="primary">
     今日の情報を登録する
   </button></ng-template
 >
@@ -25,7 +25,7 @@
           <div class="spacer"></div>
           <mat-card-actions>
             <button
-              [routerLink]="['/daily-detail', dailyInfo.dailyId]"
+              [routerLink]="['/daily-detail', dailyInfo.date]"
               mat-icon-button
               color="primary"
             >

--- a/src/app/top/detail/detail.component.ts
+++ b/src/app/top/detail/detail.component.ts
@@ -29,5 +29,11 @@ export class DetailComponent implements OnInit {
     const d = new Date();
     return this.datepipe.transform(d, 'yy.MM.dd(E)');
   }
+  createDailyInfo() {
+    this.dailyInfoService.createDailyInfo({
+      authorId: this.authService.uid,
+      date: this.date,
+    });
+  }
   ngOnInit(): void {}
 }

--- a/src/app/update/update/update.component.ts
+++ b/src/app/update/update/update.component.ts
@@ -15,7 +15,7 @@ import { Location } from '@angular/common';
 })
 export class UpdateComponent implements OnInit {
   @Input() dailyInfo: DailyInfo;
-  dailyId: string;
+  date: string;
   dailyInfo$: Observable<DailyInfo>;
 
   form = this.fb.group({
@@ -32,39 +32,24 @@ export class UpdateComponent implements OnInit {
     private location: Location
   ) {
     this.route.paramMap.subscribe((params) => {
-      this.dailyId = params.get('id');
+      this.date = params.get('date');
       this.dailyInfoService
-        .getDailyInfo(this.authService.uid, this.dailyId)
+        .getDailyInfo(this.authService.uid, this.date)
         .subscribe((dailyInfo) => {
           if (dailyInfo) {
             this.form.patchValue(dailyInfo);
-            console.log('wataru');
           } else {
             console.log('error');
           }
         });
     });
-    // this.route.queryParamMap.subscribe((params) => {
-    //   const id = params.get('id');
-
-    //   this.dailyInfoService
-    //     .getDailyInfo(this.authService.uid, id)
-    //     .subscribe((user) => {
-    //       if (user) {
-    //         this.form.patchValue(user);
-    //         console.log('wataru');
-    //       } else {
-    //         console.log('error');
-    //       }
-    //     });
-    // });
   }
   ngOnInit() {}
 
   updateSubmit() {
     const formData = this.form.value;
-    this.dailyInfoService.updateDailyInfo({
-      dailyId: this.dailyId,
+    this.dailyInfoService.updateDailyInfoBody({
+      date: this.date,
       currentWeight: formData.currentWeight,
       currentFat: formData.currentFat,
       dailyMemo: formData.dailyMemo,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,6 +17,9 @@ body {
   border-top: 1px solid #000;
   opacity: 0.2;
 }
+.container {
+  padding: 0 8px;
+}
 
 .meal__card {
   display: flex;


### PR DESCRIPTION
fix #29 

当日分の各情報を登録するページの一覧画面の作成を行いました。
ご確認お願いします。

## Detail
- エディターリスト画面作成
- 各編集ページへの遷移機能追加
- ＋ボタンを押すことでその日のdaily-info作成
- 既にあればページ遷移のみ

## Image
![image](https://user-images.githubusercontent.com/63537174/82851063-84e87300-9f39-11ea-8460-d5f2f10ccf88.png)
