### PR TITLE
レシピ詳細画面実装

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -17,6 +17,15 @@ const routes: Routes = [
     canActivate: [AuthGuard],
   },
   {
+    path: 'recipe-detail',
+    loadChildren: () =>
+      import('./menu/recipe/recipe-detail/recipe-detail.module').then(
+        (m) => m.RecipeDetailModule
+      ),
+    canLoad: [AuthGuard],
+    canActivate: [AuthGuard],
+  },
+  {
     path: 'more',
     component: OtherShellComponent,
     children: [
@@ -97,15 +106,6 @@ const routes: Routes = [
         path: 'menu',
         loadChildren: () =>
           import('./menu/menu.module').then((m) => m.MenuModule),
-        canLoad: [AuthGuard],
-        canActivate: [AuthGuard],
-      },
-      {
-        path: 'recipe-detail',
-        loadChildren: () =>
-          import('./menu/recipe/recipe-detail/recipe-detail.module').then(
-            (m) => m.RecipeDetailModule
-          ),
         canLoad: [AuthGuard],
         canActivate: [AuthGuard],
       },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -100,6 +100,15 @@ const routes: Routes = [
         canLoad: [AuthGuard],
         canActivate: [AuthGuard],
       },
+      {
+        path: 'recipe-detail',
+        loadChildren: () =>
+          import('./menu/recipe/recipe-detail/recipe-detail.module').then(
+            (m) => m.RecipeDetailModule
+          ),
+        canLoad: [AuthGuard],
+        canActivate: [AuthGuard],
+      },
     ],
   },
 ];

--- a/src/app/menu/recipe/recipe-detail/recipe-detail-routing.module.ts
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { RecipeDetailComponent } from './recipe-detail.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: RecipeDetailComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class RecipeDetailRoutingModule {}

--- a/src/app/menu/recipe/recipe-detail/recipe-detail.component.html
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.component.html
@@ -1,0 +1,91 @@
+<div class="nav">
+  <button class="back-to-page" mat-icon-button routerLink="/menu">
+    <mat-icon>navigate_before</mat-icon>
+  </button>
+  <button
+    *ngIf="myRecipe ? true : false"
+    class="update-to-page"
+    mat-icon-button
+  >
+    <mat-icon color="primary">create</mat-icon>
+  </button>
+</div>
+
+<div class="contents" *ngIf="recipe$ | async as recipe">
+  <div *ngIf="recipe.recipeThumbnailURL">
+    <img class="thumbnail" [src]="recipe.recipeThumbnailURL" alt="" />
+  </div>
+  <div *ngIf="!recipe.recipeThumbnailURL">
+    <span class="no-thumbnail">No Image</span>
+  </div>
+
+  <h2 class="content__name">レシピ名</h2>
+  <div class="content">
+    <h1>{{ recipe.recipeTitle }}</h1>
+  </div>
+  <ng-container *ngIf="recipe.recipeDescription">
+    <h2 class="content__name">ポイント</h2>
+    <div class="content">
+      <p class="content__point">
+        <span>{{ recipe.recipeDescription }}</span>
+      </p>
+    </div>
+  </ng-container>
+  <h2 class="content__name">材料</h2>
+  <div class="content" *ngFor="let food of recipe.foods">
+    <p>{{ food.name }}</p>
+    <p>{{ food.amountAndUnit }}</p>
+  </div>
+  <ng-container *ngIf="recipe.processes[0]">
+    <h2 class="content__name">作り方</h2>
+    <div class="processes">
+      <div
+        class="process"
+        *ngFor="let process of recipe.processes; let i = index"
+      >
+        <div class="process__wrapper">
+          <p>{{ i + 1 }}</p>
+          <img [src]="process.photoURL" alt="" />
+        </div>
+        <p class="process__description">{{ process.description }}</p>
+      </div>
+      <div class="border"></div>
+    </div>
+  </ng-container>
+  <h2 class="content__name">栄養素</h2>
+
+  <div class="nutrition">
+    <div class="nutrition__detail">
+      <h3 class="nutrition__name">総カロリー</h3>
+      <p>{{ recipe.recipelCal }}kcal</p>
+    </div>
+    <div class="nutrition__detail">
+      <h3 class="nutrition__name">タンパク質</h3>
+      <p>{{ recipe.recipeProtein }}g</p>
+    </div>
+    <div class="nutrition__detail">
+      <h3 class="nutrition__name">
+        脂質
+      </h3>
+      <p>{{ recipe.recipeFat }}g</p>
+    </div>
+    <div class="nutrition__detail">
+      <h3 class="nutrition__name">
+        糖質
+      </h3>
+      <p>{{ recipe.recipeSugar }}g</p>
+    </div>
+    <div class="nutrition__detail">
+      <h3 class="nutrition__name">
+        食物繊維
+      </h3>
+      <p>{{ recipe.recipeDietaryFiber }}g</p>
+    </div>
+    <div class="nutrition__detail">
+      <h3 class="nutrition__name">
+        炭水化物
+      </h3>
+      <p>{{ recipe.recipeTotalCarbohydrate }}g</p>
+    </div>
+  </div>
+</div>

--- a/src/app/menu/recipe/recipe-detail/recipe-detail.component.scss
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.component.scss
@@ -1,0 +1,95 @@
+.nav {
+  position: absolute;
+  width: 95%;
+  position: fixed;
+  top: 8px;
+  z-index: 5px;
+  display: flex;
+  justify-content: space-between;
+  padding: 8px;
+}
+.thumbnail {
+  height: 245px;
+  background: center/cover;
+  margin-bottom: 32px;
+}
+.no-thumbnail {
+  height: 150px;
+  width: 100%;
+  background: #c6c6c6;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 32px;
+}
+h1 {
+  font-size: 18px;
+  font-weight: normal;
+  margin: 0;
+}
+h2 {
+  padding-left: 8px;
+  font-size: 14px;
+  font-weight: normal;
+  margin: 0;
+}
+h3 {
+  font-size: 16px;
+  font-weight: normal;
+  margin: 0;
+}
+.content {
+  border-top: 1px solid #dbdbdb;
+  border-bottom: 1px solid #dbdbdb;
+  margin-bottom: 24px;
+  padding: 0 8px;
+  background: #ffff;
+  display: flex;
+  justify-content: space-between;
+  p {
+    margin: 0;
+  }
+  &__point {
+    height: 120px;
+  }
+}
+.processes {
+  margin-bottom: 32px;
+}
+.process {
+  display: flex;
+  background: #ffff;
+  border-top: 1px solid #dbdbdb;
+  padding: 8px;
+  &__wrapper {
+    display: flex;
+    margin-right: 16px;
+    p {
+      margin: 0 8px;
+      min-height: 30px;
+    }
+    img {
+      width: 65px;
+      height: 65px;
+      border-radius: 5px;
+    }
+  }
+  &__description {
+    margin: 0;
+  }
+}
+
+.nutrition {
+  border-top: 1px solid #dbdbdb;
+  background: #fff;
+  margin-bottom: 32px;
+}
+.nutrition__detail {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 8px;
+  border-bottom: 1px solid #dbdbdb;
+  p {
+    margin: 0;
+  }
+}

--- a/src/app/menu/recipe/recipe-detail/recipe-detail.component.spec.ts
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RecipeDetailComponent } from './recipe-detail.component';
+
+describe('RecipeDetailComponent', () => {
+  let component: RecipeDetailComponent;
+  let fixture: ComponentFixture<RecipeDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [RecipeDetailComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecipeDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/menu/recipe/recipe-detail/recipe-detail.component.ts
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { RecipeService } from 'src/app/services/recipe.service';
+import { Observable } from 'rxjs';
+import { AddedFood } from 'src/app/interfaces/added-food';
+import { AuthService } from 'src/app/services/auth.service';
+
+@Component({
+  selector: 'app-recipe-detail',
+  templateUrl: './recipe-detail.component.html',
+  styleUrls: ['./recipe-detail.component.scss'],
+})
+export class RecipeDetailComponent implements OnInit {
+  recipe$: Observable<AddedFood>;
+  myRecipe = false;
+  constructor(
+    private route: ActivatedRoute,
+    private recipeService: RecipeService,
+    private authService: AuthService
+  ) {
+    this.route.queryParamMap.subscribe((recipeId) => {
+      this.recipe$ = this.recipeService.getRecipeByRecipeId(recipeId.get('id'));
+    });
+    this.recipe$.subscribe((recipe) => {
+      if (recipe.authorId === this.authService.uid) {
+        this.myRecipe = true;
+      }
+    });
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/menu/recipe/recipe-detail/recipe-detail.module.ts
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { RecipeDetailRoutingModule } from './recipe-detail-routing.module';
+import { RecipeDetailComponent } from './recipe-detail.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+@NgModule({
+  declarations: [RecipeDetailComponent],
+  imports: [
+    CommonModule,
+    RecipeDetailRoutingModule,
+    MatButtonModule,
+    MatIconModule,
+  ],
+})
+export class RecipeDetailModule {}

--- a/src/app/menu/recipe/recipe.component.html
+++ b/src/app/menu/recipe/recipe.component.html
@@ -1,7 +1,12 @@
 <h1>マイレシピ</h1>
 <div class="border"></div>
 <div class="grid">
-  <div class="recipe" *ngFor="let recipe of myRecipes$ | async">
+  <div
+    class="recipe"
+    *ngFor="let recipe of myRecipes$ | async"
+    routerLink="/recipe-detail"
+    [queryParams]="{ id: recipe.recipeId }"
+  >
     <img class="recipe__thumbnail" [src]="recipe.recipeThumbnailURL" alt="" />
 
     <div class="recipe__row">

--- a/src/app/menu/recipe/recipe.component.html
+++ b/src/app/menu/recipe/recipe.component.html
@@ -29,7 +29,12 @@
 <h1>他ユーザーのレシピ</h1>
 <div class="border"></div>
 <div class="grid">
-  <div class="recipe" *ngFor="let recipe of publicRecipes$ | async">
+  <div
+    class="recipe"
+    *ngFor="let recipe of publicRecipes$ | async"
+    routerLink="/recipe-detail"
+    [queryParams]="{ id: recipe.recipeId }"
+  >
     <img class="recipe__thumbnail" [src]="recipe.recipeThumbnailURL" alt="" />
 
     <div class="recipe__row">

--- a/src/app/menu/recipe/recipe.component.scss
+++ b/src/app/menu/recipe/recipe.component.scss
@@ -30,6 +30,7 @@ h1 {
   flex-direction: column;
   border-radius: 10px;
   transition: 0.2s;
+  outline: none;
   cursor: pointer;
   &:hover {
     @include mat-elevation(2);

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -98,6 +98,10 @@ export class RecipeService {
     );
   }
 
+  getRecipeByRecipeId(recipeId: string): Observable<AddedFood> {
+    return this.db.doc<AddedFood>(`recipes/${recipeId}`).valueChanges();
+  }
+
   tentativeCreateRecipe(): Promise<void> {
     const recipeId = this.db.createId();
     return this.db


### PR DESCRIPTION
fix #75 #76 
レシピ詳細画面を以下の通り実装しましたので、ご確認お願いします。

## Detail
- [x] 構成整理
- [x] マークアップ
- [x] DBからのデータ抽出・表示
- 自分のレシピは編集マーク表示/他ユーザーレシピは非表示
- 作り方、ポイントはデータ自体なければ非表示

## Image
- マイレシピ
![image](https://user-images.githubusercontent.com/63537174/84966931-bd045f80-b14d-11ea-8c86-71e585b436ec.png)


- 他ユーザーレシピ
![image](https://user-images.githubusercontent.com/63537174/84966894-a0682780-b14d-11ea-9308-0d3733c87439.png)
