### PR TITLE
ツールバーのUI・タイトル改善

### DIFF
--- a/src/app/billing/billing/billing.component.ts
+++ b/src/app/billing/billing/billing.component.ts
@@ -45,7 +45,7 @@ export class BillingComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private mainShellService: MainShellService
   ) {
-    this.mainShellService.setTitle('開発者を支援');
+    this.mainShellService.title = this.mainShellService.PAGE_TITLES.donation;
     this.getCards();
   }
 

--- a/src/app/daily-detail/daily-detail.component.ts
+++ b/src/app/daily-detail/daily-detail.component.ts
@@ -109,7 +109,7 @@ export class DailyDetailComponent implements OnInit, OnDestroy {
       this.date = params.get('date');
       this.getDailyInfo();
       this.getDailyInfoOfMeal();
-      this.mainShellService.setTitle(this.date);
+      this.mainShellService.title = this.date;
     });
 
     this.subscription.add(routeSub);

--- a/src/app/dialogs/tutorial/tutorial.component.ts
+++ b/src/app/dialogs/tutorial/tutorial.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { AuthService } from 'src/app/services/auth.service';
 import { MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { OthreShellService } from 'src/app/services/othre-shell.service';
 
 @Component({
   selector: 'app-tutorial',
@@ -11,15 +9,11 @@ import { OthreShellService } from 'src/app/services/othre-shell.service';
 })
 export class TutorialComponent implements OnInit {
   constructor(
-    private authService: AuthService,
     private dialogRef: MatDialogRef<TutorialComponent>,
-    private router: Router,
-    private otherShellService: OthreShellService
+    private router: Router
   ) {}
 
   goToUsage() {
-    this.authService.isInitialLogin = false;
-    this.otherShellService.setPreTitle('TOP');
     this.dialogRef.close();
     this.router.navigateByUrl('/more/usage/top');
   }

--- a/src/app/dialogs/tutorial/tutorial.component.ts
+++ b/src/app/dialogs/tutorial/tutorial.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { AuthService } from 'src/app/services/auth.service';
 import { MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 
@@ -9,11 +10,13 @@ import { Router } from '@angular/router';
 })
 export class TutorialComponent implements OnInit {
   constructor(
+    private authService: AuthService,
     private dialogRef: MatDialogRef<TutorialComponent>,
     private router: Router
   ) {}
 
   goToUsage() {
+    this.authService.isInitialLogin = false;
     this.dialogRef.close();
     this.router.navigateByUrl('/more/usage/top');
   }

--- a/src/app/editor-meal/editor-meal/editor-meal.component.ts
+++ b/src/app/editor-meal/editor-meal/editor-meal.component.ts
@@ -31,10 +31,10 @@ export class EditorMealComponent implements OnInit, OnDestroy {
     const querySub = this.route.queryParamMap.subscribe((paramMaps) => {
       this.date = paramMaps.get('date');
       this.meal = paramMaps.get('meal');
-      this.mainShellService.setTitle(this.date);
+      this.mainShellService.title = this.date;
       this.getMeals();
       this.createDailyInfo();
-      this.mainShellService.setTitleMeal(this.meal);
+      this.mainShellService.titleMeal = this.meal;
     });
     this.subscription.add(querySub);
   }

--- a/src/app/graph/graph/graph.component.ts
+++ b/src/app/graph/graph/graph.component.ts
@@ -76,7 +76,7 @@ export class GraphComponent implements OnInit, OnDestroy {
     private averageService: AverageService
   ) {
     this.loading = true;
-    this.mainShellService.setTitle('グラフ');
+    this.mainShellService.title = this.mainShellService.PAGE_TITLES.graph;
     this.initResize();
     this.setGoalList();
     this.createGraphOfDay(this.today);

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -87,14 +87,14 @@
         <a
           mat-icon-button
           color="primary"
-          [matTooltip]="mainShellService.PAGE_TITLES.graph"
+          [matTooltip]="mainShellService.PAGE_TITLES.menu"
           aria-label="Button that displays a tooltip when focused or hovered over"
           class="navs__item"
           routerLink="/menu/set-list"
         >
           <mat-icon
             [fontSet]="
-              mainShellService.title === mainShellService.PAGE_TITLES.graph
+              mainShellService.title === mainShellService.PAGE_TITLES.menu
                 ? 'material-icons'
                 : 'material-icons-outlined'
             "

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -70,14 +70,14 @@
         <a
           mat-icon-button
           color="primary"
-          matTooltip="グラフ"
+          [matTooltip]="mainShellService.PAGE_TITLES.graph"
           aria-label="Button that displays a tooltip when focused or hovered over"
           class="navs__item"
           routerLink="/graph"
         >
           <mat-icon
             [fontSet]="
-              mainShellService.title === 'グラフ'
+              mainShellService.title === mainShellService.PAGE_TITLES.graph
                 ? 'material-icons'
                 : 'material-icons-outlined'
             "
@@ -87,14 +87,14 @@
         <a
           mat-icon-button
           color="primary"
-          matTooltip="マイメニュー"
+          [matTooltip]="mainShellService.PAGE_TITLES.graph"
           aria-label="Button that displays a tooltip when focused or hovered over"
           class="navs__item"
           routerLink="/menu/set-list"
         >
           <mat-icon
             [fontSet]="
-              mainShellService.title === 'マイメニュー'
+              mainShellService.title === mainShellService.PAGE_TITLES.graph
                 ? 'material-icons'
                 : 'material-icons-outlined'
             "

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -116,7 +116,7 @@
             <mat-icon>login</mat-icon>
             <span>ログアウト</span>
           </button>
-          <a mat-menu-item *ngIf="more" routerLink="/more">
+          <a mat-menu-item routerLink="/more">
             <mat-icon>more_horiz</mat-icon>
             <span>その他</span>
           </a>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -120,6 +120,10 @@
             <mat-icon>more_horiz</mat-icon>
             <span>その他</span>
           </a>
+          <a mat-menu-item routerLink="/more/usage/top">
+            <mat-icon>help_outline</mat-icon>
+            <span>使用方法</span>
+          </a>
           <a mat-menu-item routerLink="/billing">
             <mat-icon>support</mat-icon>
             <span>開発者を応援する</span>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -7,15 +7,15 @@
     <div class="spacer"></div>
 
     <ng-container *ngIf="!selectedValue">
-      <h1 class="title" *ngIf="!(title$ | async).includes('2')">
-        {{ title$ | async }}
+      <h1 class="title" *ngIf="!mainShellService.title.includes('2')">
+        {{ mainShellService.title }}
       </h1>
       <h1
-        *ngIf="(title$ | async).includes('2')"
+        *ngIf="mainShellService.title.includes('2')"
         class="title title--date"
         (click)="picker.open()"
       >
-        {{ title$ | async
+        {{ mainShellService.title
         }}<mat-icon class="title__icon">arrow_drop_down</mat-icon>
       </h1>
       <mat-form-field class="example-full-width" style="display: none;">
@@ -34,7 +34,7 @@
     <div class="header__meal" *ngIf="selectedValue">
       <ng-container>
         <h1 class="other-title" (click)="picker.open()">
-          {{ title$ | async }}
+          {{ mainShellService.title }}
         </h1>
         <mat-form-field class="example-full-width" style="display: none;">
           <input
@@ -77,7 +77,7 @@
         >
           <mat-icon
             [fontSet]="
-              (title$ | async) === 'グラフ'
+              mainShellService.title === 'グラフ'
                 ? 'material-icons'
                 : 'material-icons-outlined'
             "
@@ -94,7 +94,7 @@
         >
           <mat-icon
             [fontSet]="
-              (title$ | async) === 'マイメニュー'
+              mainShellService.title === 'マイメニュー'
                 ? 'material-icons'
                 : 'material-icons-outlined'
             "

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -19,7 +19,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
   avatarURL: string;
   selectedValue: string;
   mealTitle: string;
-  more = false;
   viewX: number;
   maxDate = new Date();
   minDate = new Date(2018, 0, 1);
@@ -40,11 +39,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
       });
 
     const routeSub = this.getParam();
-
-    if (innerWidth > 750) {
-      this.more = true;
-      this.viewX = innerWidth / 2;
-    }
 
     this.subscription.add(basicInfoSub);
     this.subscription.add(routeSub);

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MainShellService } from '../services/main-shell.service';
-import { Observable, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DailyInfoService } from '../services/daily-info.service';
@@ -15,8 +15,6 @@ import { BasicInfoService } from '../services/basic-info.service';
 export class HeaderComponent implements OnInit, OnDestroy {
   private subscription: Subscription = new Subscription();
 
-  title$: Observable<string> = this.mainShellService.title$;
-  titleMeal$: Observable<string> = this.mainShellService.titleMeal$;
   date: string;
   avatarURL: string;
   selectedValue: string;
@@ -27,7 +25,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   minDate = new Date(2018, 0, 1);
 
   constructor(
-    private mainShellService: MainShellService,
+    public mainShellService: MainShellService,
     private authService: AuthService,
     private route: ActivatedRoute,
     private dailyInfoService: DailyInfoService,

--- a/src/app/menu/menu/menu.component.ts
+++ b/src/app/menu/menu/menu.component.ts
@@ -15,7 +15,7 @@ export class MenuComponent implements OnInit {
     private dailyInfoService: DailyInfoService,
     private mainShellService: MainShellService
   ) {
-    this.mainShellService.setTitle('マイメニュー');
+    this.mainShellService.title = this.mainShellService.PAGE_TITLES.menu;
   }
 
   backToMeal() {

--- a/src/app/more/account/account.component.ts
+++ b/src/app/more/account/account.component.ts
@@ -25,7 +25,7 @@ export class AccountComponent implements OnInit {
     private authService: AuthService,
     private dialog: MatDialog
   ) {
-    this.othreShellService.setTitle('アカウント削除');
+    this.othreShellService.title = this.othreShellService.PAGE_TITLES.account;
   }
 
   openDeleteDialog(): void {

--- a/src/app/more/legal/legal.component.ts
+++ b/src/app/more/legal/legal.component.ts
@@ -8,7 +8,7 @@ import { OthreShellService } from 'src/app/services/othre-shell.service';
 })
 export class LegalComponent implements OnInit {
   constructor(private othreShellService: OthreShellService) {
-    this.othreShellService.setTitle('特定商取引法に基づく表示');
+    this.othreShellService.title = this.othreShellService.PAGE_TITLES.legal;
   }
 
   ngOnInit(): void {}

--- a/src/app/more/more/more.component.html
+++ b/src/app/more/more/more.component.html
@@ -5,12 +5,6 @@
       <mat-icon>keyboard_arrow_right</mat-icon>
     </div>
   </a>
-  <a class="list" mat-stroked-button routerLink="/more/usage/top">
-    <div class="wrapper">
-      <p>使用方法</p>
-      <mat-icon>keyboard_arrow_right</mat-icon>
-    </div>
-  </a>
   <a class="list" mat-stroked-button routerLink="/more/terms">
     <div class="wrapper">
       <p>利用規約</p>

--- a/src/app/more/more/more.component.ts
+++ b/src/app/more/more/more.component.ts
@@ -12,7 +12,7 @@ export class MoreComponent implements OnInit {
     private othreShellService: OthreShellService,
     private mainShellService: MainShellService
   ) {
-    this.othreShellService.setTitle('その他');
+    this.othreShellService.title = this.othreShellService.PAGE_TITLES.more;
     this.mainShellService.title = this.mainShellService.PAGE_TITLES.more;
   }
 

--- a/src/app/more/more/more.component.ts
+++ b/src/app/more/more/more.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MainShellService } from 'src/app/services/main-shell.service';
 import { OthreShellService } from 'src/app/services/othre-shell.service';
 
 @Component({
@@ -7,8 +8,12 @@ import { OthreShellService } from 'src/app/services/othre-shell.service';
   styleUrls: ['./more.component.scss'],
 })
 export class MoreComponent implements OnInit {
-  constructor(private othreShellService: OthreShellService) {
+  constructor(
+    private othreShellService: OthreShellService,
+    private mainShellService: MainShellService
+  ) {
     this.othreShellService.setTitle('その他');
+    this.mainShellService.title = this.mainShellService.PAGE_TITLES.more;
   }
 
   ngOnInit(): void {}

--- a/src/app/more/profile/profile.component.ts
+++ b/src/app/more/profile/profile.component.ts
@@ -70,7 +70,7 @@ export class ProfileComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private dialog: MatDialog
   ) {
-    this.otherShellService.setTitle('ユーザー情報');
+    this.otherShellService.title = this.otherShellService.PAGE_TITLES.profile;
     this.getBasicInfo();
   }
 

--- a/src/app/more/terms/terms.component.ts
+++ b/src/app/more/terms/terms.component.ts
@@ -8,7 +8,7 @@ import { OthreShellService } from 'src/app/services/othre-shell.service';
 })
 export class TermsComponent implements OnInit {
   constructor(private othreShellService: OthreShellService) {
-    this.othreShellService.setTitle('利用規約');
+    this.othreShellService.title = this.othreShellService.PAGE_TITLES.terms;
   }
 
   ngOnInit(): void {}

--- a/src/app/more/usage/usage.component.ts
+++ b/src/app/more/usage/usage.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MainShellService } from 'src/app/services/main-shell.service';
 import { OthreShellService } from 'src/app/services/othre-shell.service';
 
 @Component({
@@ -7,9 +8,13 @@ import { OthreShellService } from 'src/app/services/othre-shell.service';
   styleUrls: ['./usage.component.scss'],
 })
 export class UsageComponent implements OnInit {
-  constructor(private otherShellService: OthreShellService) {
-    this.otherShellService.title = this.otherShellService.PAGE_TITLES.usage;
-  }
+  constructor(
+    private otherShellService: OthreShellService,
+    private mainShellService: MainShellService
+  ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.otherShellService.title = this.otherShellService.PAGE_TITLES.usage;
+    this.mainShellService.title = this.otherShellService.PAGE_TITLES.usage;
+  }
 }

--- a/src/app/more/usage/usage.component.ts
+++ b/src/app/more/usage/usage.component.ts
@@ -8,7 +8,7 @@ import { OthreShellService } from 'src/app/services/othre-shell.service';
 })
 export class UsageComponent implements OnInit {
   constructor(private otherShellService: OthreShellService) {
-    this.otherShellService.setTitle('使用方法');
+    this.otherShellService.title = this.otherShellService.PAGE_TITLES.usage;
   }
 
   ngOnInit(): void {}

--- a/src/app/other-shell/other-shell.component.html
+++ b/src/app/other-shell/other-shell.component.html
@@ -3,7 +3,8 @@
     <mat-toolbar-row class="toolbar__content">
       <ng-container
         *ngIf="
-          othreShellService.title === othreShellService.PAGE_TITLES.more;
+          othreShellService.title === othreShellService.PAGE_TITLES.more ||
+            othreShellService.title === othreShellService.PAGE_TITLES.usage;
           else eachPage
         "
       >
@@ -29,7 +30,10 @@
 
       <div
         class="navs"
-        *ngIf="othreShellService.title === othreShellService.PAGE_TITLES.more"
+        *ngIf="
+          othreShellService.title === othreShellService.PAGE_TITLES.more ||
+          othreShellService.title === othreShellService.PAGE_TITLES.usage
+        "
       >
         <a
           mat-icon-button
@@ -54,7 +58,10 @@
       </div>
       <div
         class="mypage"
-        *ngIf="othreShellService.title === othreShellService.PAGE_TITLES.more"
+        *ngIf="
+          othreShellService.title === othreShellService.PAGE_TITLES.more ||
+          othreShellService.title === othreShellService.PAGE_TITLES.usage
+        "
       >
         <button mat-icon-button [matMenuTriggerFor]="menu">
           <img
@@ -78,6 +85,10 @@
           <a mat-menu-item routerLink="/more">
             <mat-icon>more_horiz</mat-icon>
             <span>その他</span>
+          </a>
+          <a mat-menu-item routerLink="/more/usage/top">
+            <mat-icon>help_outline</mat-icon>
+            <span>使用方法</span>
           </a>
           <a mat-menu-item routerLink="/billing">
             <mat-icon>support</mat-icon>

--- a/src/app/other-shell/other-shell.component.html
+++ b/src/app/other-shell/other-shell.component.html
@@ -4,7 +4,7 @@
       <ng-container
         *ngIf="
           othreShellService.title === othreShellService.PAGE_TITLES.more;
-          else other
+          else eachPage
         "
       >
         <a class="logo" routerLink="">
@@ -12,7 +12,7 @@
         </a>
       </ng-container>
 
-      <ng-template #other>
+      <ng-template #eachPage>
         <button mat-button (click)="backToPage()" class="toolbar__back">
           <mat-icon>keyboard_arrow_left</mat-icon><span>戻る</span>
         </button>

--- a/src/app/other-shell/other-shell.component.html
+++ b/src/app/other-shell/other-shell.component.html
@@ -14,9 +14,9 @@
       </ng-container>
 
       <ng-template #eachPage>
-        <button mat-button (click)="backToPage()" class="toolbar__back">
+        <a mat-button routerLink="/more" class="toolbar__back">
           <mat-icon>keyboard_arrow_left</mat-icon><span>戻る</span>
-        </button>
+        </a>
       </ng-template>
       <h1
         [ngClass]="

--- a/src/app/other-shell/other-shell.component.html
+++ b/src/app/other-shell/other-shell.component.html
@@ -1,7 +1,12 @@
 <div>
   <mat-toolbar class="toolbar">
     <mat-toolbar-row class="toolbar__content">
-      <ng-container *ngIf="(title$ | async) === 'その他'; else other">
+      <ng-container
+        *ngIf="
+          othreShellService.title === othreShellService.PAGE_TITLES.more;
+          else other
+        "
+      >
         <a class="logo" routerLink="">
           <img class="logo__image" src="/assets/images/logo.svg" alt="" />
         </a>
@@ -14,15 +19,18 @@
       </ng-template>
       <h1
         [ngClass]="
-          (title$ | async) !== '特定商取引法に基づく表示'
+          othreShellService.title !== othreShellService.PAGE_TITLES.legal
             ? 'toolbar__title'
             : 'toolbar__title toolbar__title--legal'
         "
       >
-        {{ title$ | async }}
+        {{ othreShellService.title }}
       </h1>
 
-      <div class="navs" *ngIf="(title$ | async) === 'その他'">
+      <div
+        class="navs"
+        *ngIf="othreShellService.title === othreShellService.PAGE_TITLES.more"
+      >
         <a
           mat-icon-button
           color="primary"
@@ -31,14 +39,7 @@
           class="navs__item"
           routerLink="/graph"
         >
-          <mat-icon
-            [fontSet]="
-              (title$ | async) === 'グラフ'
-                ? 'material-icons'
-                : 'material-icons-outlined'
-            "
-            >insert_chart</mat-icon
-          >
+          <mat-icon fontSet="material-icons-outlined">insert_chart</mat-icon>
         </a>
         <a
           mat-icon-button
@@ -48,17 +49,13 @@
           class="navs__item"
           routerLink="/menu/set-list"
         >
-          <mat-icon
-            [fontSet]="
-              (title$ | async) === 'マイメニュー'
-                ? 'material-icons'
-                : 'material-icons-outlined'
-            "
-            >library_books</mat-icon
-          >
+          <mat-icon fontSet="material-icons-outlined">library_books</mat-icon>
         </a>
       </div>
-      <div class="mypage" *ngIf="(title$ | async) === 'その他'">
+      <div
+        class="mypage"
+        *ngIf="othreShellService.title === othreShellService.PAGE_TITLES.more"
+      >
         <button mat-icon-button [matMenuTriggerFor]="menu">
           <img
             *ngIf="basicInfo$ | async as basicInfo"

--- a/src/app/other-shell/other-shell.component.ts
+++ b/src/app/other-shell/other-shell.component.ts
@@ -1,21 +1,17 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
 import { OthreShellService } from '../services/othre-shell.service';
 import { AuthService } from '../services/auth.service';
 import { BasicInfoService } from '../services/basic-info.service';
 import { BasicInfo } from '../interfaces/basic-info';
 import { Router } from '@angular/router';
-import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-other-shell',
   templateUrl: './other-shell.component.html',
   styleUrls: ['./other-shell.component.scss'],
 })
-export class OtherShellComponent implements OnInit, OnDestroy {
-  private prePageTitle: string;
-  private prePageSubscription: Subscription;
-
+export class OtherShellComponent implements OnInit {
   title$: Observable<string> = this.othreShellService.title$;
   basicInfo$: Observable<BasicInfo> = this.basicInfoService.getBasicInfo(
     this.authService.uid
@@ -26,16 +22,11 @@ export class OtherShellComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private basicInfoService: BasicInfoService,
     private router: Router
-  ) {
-    this.prePageSubscription = this.othreShellService.preTitle$.subscribe(
-      (preTitle) => {
-        return (this.prePageTitle = preTitle);
-      }
-    );
-  }
+  ) {}
 
   backToPage(): Promise<boolean> {
-    if (this.prePageTitle === 'TOP') {
+    if (this.authService.isInitialLogin) {
+      this.authService.isInitialLogin = false;
       return this.router.navigateByUrl('');
     } else {
       return this.router.navigateByUrl('/more');
@@ -47,8 +38,4 @@ export class OtherShellComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {}
-
-  ngOnDestroy(): void {
-    this.prePageSubscription.unsubscribe();
-  }
 }

--- a/src/app/other-shell/other-shell.component.ts
+++ b/src/app/other-shell/other-shell.component.ts
@@ -12,7 +12,6 @@ import { Router } from '@angular/router';
   styleUrls: ['./other-shell.component.scss'],
 })
 export class OtherShellComponent implements OnInit {
-  title$: Observable<string> = this.othreShellService.title$;
   basicInfo$: Observable<BasicInfo> = this.basicInfoService.getBasicInfo(
     this.authService.uid
   );

--- a/src/app/other-shell/other-shell.component.ts
+++ b/src/app/other-shell/other-shell.component.ts
@@ -18,7 +18,7 @@ export class OtherShellComponent implements OnInit {
   );
 
   constructor(
-    private othreShellService: OthreShellService,
+    public othreShellService: OthreShellService,
     private authService: AuthService,
     private basicInfoService: BasicInfoService,
     private router: Router

--- a/src/app/services/main-shell.service.ts
+++ b/src/app/services/main-shell.service.ts
@@ -6,25 +6,28 @@ import { DailyMeal } from '../interfaces/daily-info';
   providedIn: 'root',
 })
 export class MainShellService {
-  private readonly titleSource = new ReplaySubject<string>();
-  private readonly titleMealSource = new ReplaySubject<string>();
   private readonly selectedMealsSource = new ReplaySubject<DailyMeal[]>();
   private readonly paymentCompletedSource = new ReplaySubject<void>();
 
-  title$ = this.titleSource.asObservable();
-  titleMeal$ = this.titleMealSource.asObservable();
+  readonly PAGE_TITLES = {
+    top: 'TOP',
+    graph: 'グラフ',
+    menu: 'マイメニュー',
+    more: 'その他',
+    donation: '開発者を支援',
+  };
+  readonly MEAL_TITLES = {
+    breakfast: 'breakfast',
+    lunch: 'lunch',
+    dinner: 'dinner',
+  };
+
+  title: string;
+  titleMeal: string;
   selectedMeals = this.selectedMealsSource.asObservable();
   paymentCompleted$ = this.paymentCompletedSource.asObservable();
 
   constructor() {}
-
-  setTitle(title: string) {
-    this.titleSource.next(title);
-  }
-
-  setTitleMeal(titleMeal: string) {
-    this.titleMealSource.next(titleMeal);
-  }
 
   setSelectedMeals(selectedMeals: DailyMeal[]) {
     this.selectedMealsSource.next(selectedMeals);

--- a/src/app/services/othre-shell.service.ts
+++ b/src/app/services/othre-shell.service.ts
@@ -1,23 +1,17 @@
 import { Injectable } from '@angular/core';
-import { ReplaySubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class OthreShellService {
-  titleSource = new ReplaySubject<string>();
-  title$ = this.titleSource.asObservable();
-
-  preTitleSource = new ReplaySubject<string>();
-  preTitle$ = this.preTitleSource.asObservable();
+  readonly PAGE_TITLES = {
+    more: 'その他',
+    profile: 'ユーザー情報',
+    legal: '特定商取引法に基づく表示',
+    terms: '利用規約',
+    account: 'アカウント削除',
+  };
+  title: string;
 
   constructor() {}
-
-  setTitle(title: string) {
-    this.titleSource.next(title);
-  }
-
-  setPreTitle(title: string) {
-    this.preTitleSource.next(title);
-  }
 }

--- a/src/app/services/othre-shell.service.ts
+++ b/src/app/services/othre-shell.service.ts
@@ -7,6 +7,7 @@ export class OthreShellService {
   readonly PAGE_TITLES = {
     more: 'その他',
     profile: 'ユーザー情報',
+    usage: '使用方法',
     legal: '特定商取引法に基づく表示',
     terms: '利用規約',
     account: 'アカウント削除',

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -28,7 +28,6 @@
       >
       <div class="nav__text"><span>グラフ</span></div>
     </a>
-
     <a
       mat-button
       class="nav"
@@ -45,16 +44,6 @@
         >library_books</mat-icon
       >
       <div class="nav__text"><span>マイメニュー</span></div>
-    </a>
-    <a mat-button class="nav" routerLink="/more">
-      <mat-icon
-        [fontSet]="
-          morePage === 'more' ? 'material-icons' : 'material-icons-outlined'
-        "
-        class="nav__icon"
-        >person</mat-icon
-      >
-      <div class="nav__text"><span>その他</span></div>
     </a>
   </mat-toolbar-row></mat-toolbar
 >

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -3,9 +3,9 @@
     <a mat-button class="nav" routerLink="">
       <mat-icon
         [fontSet]="
-          (pageTitle$ | async) !== 'グラフ' &&
-          (pageTitle$ | async) !== 'マイメニュー' &&
-          morePage !== 'more'
+          mainShellService.title !== mainShellService.PAGE_TITLES.graph &&
+          mainShellService.title !== mainShellService.PAGE_TITLES.menu &&
+          morePage !== mainShellService.PAGE_TITLES.more
             ? 'material-icons'
             : 'material-icons-outlined'
         "
@@ -13,20 +13,23 @@
         >home</mat-icon
       >
       <div class="nav__text">
-        <span>TOP</span>
+        <span>{{ mainShellService.PAGE_TITLES.top }}</span>
       </div>
     </a>
     <a mat-button class="nav" routerLink="/graph">
       <mat-icon
         [fontSet]="
-          (pageTitle$ | async) === 'グラフ' && morePage !== 'more'
+          mainShellService.title === mainShellService.PAGE_TITLES.graph &&
+          morePage !== mainShellService.PAGE_TITLES.more
             ? 'material-icons'
             : 'material-icons-outlined'
         "
         class="nav__icon"
         >insert_chart</mat-icon
       >
-      <div class="nav__text"><span>グラフ</span></div>
+      <div class="nav__text">
+        <span>{{ mainShellService.PAGE_TITLES.graph }}</span>
+      </div>
     </a>
     <a
       mat-button
@@ -36,14 +39,17 @@
     >
       <mat-icon
         [fontSet]="
-          (pageTitle$ | async) === 'マイメニュー' && morePage !== 'more'
+          mainShellService.title === mainShellService.PAGE_TITLES.menu &&
+          morePage !== mainShellService.PAGE_TITLES.more
             ? 'material-icons'
             : 'material-icons-outlined'
         "
         class="nav__icon"
         >library_books</mat-icon
       >
-      <div class="nav__text"><span>マイメニュー</span></div>
+      <div class="nav__text">
+        <span>{{ mainShellService.PAGE_TITLES.menu }}</span>
+      </div>
     </a>
   </mat-toolbar-row></mat-toolbar
 >

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -1,5 +1,5 @@
-<mat-toolbar color="primary" *ngIf="toolbar">
-  <mat-toolbar-row class="toolbar">
+<mat-toolbar color="primary" class="toolbar">
+  <mat-toolbar-row class="toolbar__row">
     <a mat-button class="nav" routerLink="">
       <mat-icon
         [fontSet]="

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -3,9 +3,7 @@
     <a mat-button class="nav" routerLink="">
       <mat-icon
         [fontSet]="
-          mainShellService.title !== mainShellService.PAGE_TITLES.graph &&
-          mainShellService.title !== mainShellService.PAGE_TITLES.menu &&
-          morePage !== mainShellService.PAGE_TITLES.more
+          mainShellService.title === mainShellService.PAGE_TITLES.top
             ? 'material-icons'
             : 'material-icons-outlined'
         "
@@ -19,8 +17,7 @@
     <a mat-button class="nav" routerLink="/graph">
       <mat-icon
         [fontSet]="
-          mainShellService.title === mainShellService.PAGE_TITLES.graph &&
-          morePage !== mainShellService.PAGE_TITLES.more
+          mainShellService.title === mainShellService.PAGE_TITLES.graph
             ? 'material-icons'
             : 'material-icons-outlined'
         "
@@ -39,8 +36,7 @@
     >
       <mat-icon
         [fontSet]="
-          mainShellService.title === mainShellService.PAGE_TITLES.menu &&
-          morePage !== mainShellService.PAGE_TITLES.more
+          mainShellService.title === mainShellService.PAGE_TITLES.menu
             ? 'material-icons'
             : 'material-icons-outlined'
         "

--- a/src/app/toolbar/toolbar.component.scss
+++ b/src/app/toolbar/toolbar.component.scss
@@ -1,14 +1,15 @@
 .toolbar {
   height: 56px;
   display: grid;
-  grid-template-columns: repeat(4, 25%);
+  grid-template-columns: repeat(3, auto);
   justify-items: center;
   align-items: center;
+  padding: 0;
 }
 
 .nav {
   line-height: 28px;
-  padding: 0 8px;
+  padding: 0;
 
   &__text {
     font-size: 11px;

--- a/src/app/toolbar/toolbar.component.scss
+++ b/src/app/toolbar/toolbar.component.scss
@@ -1,10 +1,16 @@
 .toolbar {
-  height: 56px;
-  display: grid;
-  grid-template-columns: repeat(3, auto);
-  justify-items: center;
-  align-items: center;
-  padding: 0;
+  @media screen and(min-width:750px) {
+    display: none;
+  }
+
+  &__row {
+    height: 56px;
+    display: grid;
+    grid-template-columns: repeat(3, auto);
+    justify-items: center;
+    align-items: center;
+    padding: 0;
+  }
 }
 
 .nav {

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -14,7 +14,7 @@ export class ToolbarComponent implements OnInit {
   constructor(
     private dailyInfoService: DailyInfoService,
     private router: Router,
-    private mainShellService: MainShellService
+    public mainShellService: MainShellService
   ) {
     this.morePage = this.router.url.split('/')[1];
   }

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -9,15 +9,10 @@ import { MainShellService } from '../services/main-shell.service';
   styleUrls: ['./toolbar.component.scss'],
 })
 export class ToolbarComponent implements OnInit {
-  morePage: string;
-
   constructor(
     private dailyInfoService: DailyInfoService,
-    private router: Router,
     public mainShellService: MainShellService
-  ) {
-    this.morePage = this.router.url.split('/')[1];
-  }
+  ) {}
 
   changeQuery() {
     this.dailyInfoService.queryParams = null;

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { DailyInfoService } from '../services/daily-info.service';
-import { Router } from '@angular/router';
 import { MainShellService } from '../services/main-shell.service';
 
 @Component({

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,12 +1,7 @@
-import { Component, OnInit, Input } from '@angular/core';
-import { DatePipe } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
 import { DailyInfoService } from '../services/daily-info.service';
-import { AuthService } from '../services/auth.service';
-import { DailyInfo } from '../interfaces/daily-info';
 import { Router } from '@angular/router';
 import { MainShellService } from '../services/main-shell.service';
-import { Observable } from 'rxjs';
-import { OthreShellService } from '../services/othre-shell.service';
 
 @Component({
   selector: 'app-toolbar',
@@ -14,35 +9,16 @@ import { OthreShellService } from '../services/othre-shell.service';
   styleUrls: ['./toolbar.component.scss'],
 })
 export class ToolbarComponent implements OnInit {
-  @Input() dailyInfo: DailyInfo;
-  date: string = this.getDate();
-  toolbar = true;
-  pageTitle$: Observable<string> = this.mainShellService.title$;
   morePage: string;
 
   constructor(
     private dailyInfoService: DailyInfoService,
-    private authService: AuthService,
-    private datepipe: DatePipe,
     private router: Router,
     private mainShellService: MainShellService
   ) {
     this.morePage = this.router.url.split('/')[1];
-    if (innerWidth > 750) {
-      this.toolbar = false;
-    }
   }
-  getDate() {
-    const d = new Date();
-    return this.datepipe.transform(d, 'yy.MM.dd(E)');
-  }
-  createDailyInfo() {
-    this.dailyInfoService.createDailyInfo({
-      authorId: this.authService.uid,
-      date: this.date,
-    });
-    this.router.navigateByUrl('editor-list');
-  }
+
   changeQuery() {
     this.dailyInfoService.queryParams = null;
   }

--- a/src/app/top/top/top.component.ts
+++ b/src/app/top/top/top.component.ts
@@ -64,7 +64,7 @@ export class TopComponent implements OnInit, OnDestroy {
     private datePipe: DatePipe
   ) {
     this.isInitLogin();
-    this.mainShellService.setTitle('TOP');
+    this.mainShellService.title = this.mainShellService.PAGE_TITLES.top;
     this.getDailyInfos();
   }
 


### PR DESCRIPTION
fix #167 
以下の通り改善しました。ご確認お願いします。

## Detail
### ヘッダー
- [x] タイトルを文字列で判断しない(タイトルをサービスで管理)
- [x] 使用方法へのアクセス性を解消
- [x] その他をスマホ時も出す

### スマホツールバー
- [x] タイトルを文字列で判断しない(タイトルをサービスで管理)
- [x] その他を消す
- [x] 各ボタン等分
- [x] 余白消す

### service
- [x] タイトルセット方法をsubjectなしに変更

## Image
- 下部ツールバー
![image](https://user-images.githubusercontent.com/63537174/95753900-3ca9d180-0cdd-11eb-8d46-0e627f576481.png)
