### PR TITLE
マイセットUI改善 #165

### DIFF
--- a/src/app/menu/set/set-detail/set-detail.component.html
+++ b/src/app/menu/set/set-detail/set-detail.component.html
@@ -13,12 +13,7 @@
     >
       <mat-icon>edit</mat-icon>
     </a>
-    <button
-      mat-icon-button
-      class="delete"
-      color="warn"
-      (click)="openDeleteDialog()"
-    >
+    <button mat-icon-button class="delete-button" (click)="openDeleteDialog()">
       <mat-icon>delete</mat-icon>
     </button>
   </div>

--- a/src/app/menu/set/set-detail/set-detail.component.html
+++ b/src/app/menu/set/set-detail/set-detail.component.html
@@ -1,9 +1,9 @@
 <div class="nav">
-  <button class="back-to-page" mat-icon-button routerLink="/menu/set-list">
+  <button class="nav__back-to-page" mat-icon-button routerLink="/menu/set-list">
     <mat-icon>navigate_before</mat-icon>
   </button>
   <h1>マイセット詳細画面</h1>
-  <div class="nav-wrap">
+  <div class="nav__buttons">
     <a
       class="update-to-page"
       mat-icon-button

--- a/src/app/menu/set/set-detail/set-detail.component.scss
+++ b/src/app/menu/set/set-detail/set-detail.component.scss
@@ -15,11 +15,23 @@
   top: 0;
   z-index: 5;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   height: 56px;
   background: #fff;
   @include mat-elevation(1);
+
+  &__back-to-page {
+    position: fixed;
+    top: 8px;
+    left: 8px;
+  }
+
+  &__buttons {
+    position: fixed;
+    top: 8px;
+    right: 8px;
+  }
 }
 
 .delete-button {

--- a/src/app/menu/set/set-detail/set-detail.component.scss
+++ b/src/app/menu/set/set-detail/set-detail.component.scss
@@ -38,10 +38,6 @@
   color: rgb(115, 115, 115);
 }
 
-.update-to-page {
-  margin-right: 16px;
-}
-
 h1 {
   font-size: 18px;
   font-weight: normal;

--- a/src/app/menu/set/set-detail/set-detail.component.scss
+++ b/src/app/menu/set/set-detail/set-detail.component.scss
@@ -22,6 +22,10 @@
   @include mat-elevation(1);
 }
 
+.delete-button {
+  color: rgb(115, 115, 115);
+}
+
 .update-to-page {
   margin-right: 16px;
 }

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -102,6 +102,7 @@
                             max="100"
                             min="0"
                             step="0.1"
+                            value="0"
                             #amount
                             type="number"
                             autocomplete="off"

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -342,7 +342,7 @@
                   setCalControl.hasError('min') ||
                   setCalControl.hasError('max')
                 "
-                >{{ minNutritionAmount }}-{{
+                >{{ minNutritionAmount }}〜{{
                   maxNutritionAmount
                 }}の範囲で調整してください</mat-error
               >
@@ -372,7 +372,7 @@
                   setProteinControl.hasError('min') ||
                   setProteinControl.hasError('max')
                 "
-                >{{ minNutritionAmount }}-{{
+                >{{ minNutritionAmount }}〜{{
                   maxNutritionAmount
                 }}の範囲で調整してください</mat-error
               >
@@ -402,7 +402,7 @@
                   setFatControl.hasError('min') ||
                   setFatControl.hasError('max')
                 "
-                >{{ minNutritionAmount }}-{{
+                >{{ minNutritionAmount }}〜{{
                   maxNutritionAmount
                 }}の範囲で調整してください</mat-error
               ></mat-form-field
@@ -432,7 +432,7 @@
                   setTotalCarbohydrateControl.hasError('min') ||
                   setTotalCarbohydrateControl.hasError('max')
                 "
-                >{{ minNutritionAmount }}-{{
+                >{{ minNutritionAmount }}〜{{
                   maxNutritionAmount
                 }}の範囲で調整してください</mat-error
               ></mat-form-field
@@ -462,7 +462,7 @@
                   setDietaryFiberControl.hasError('min') ||
                   setDietaryFiberControl.hasError('max')
                 "
-                >{{ minNutritionAmount }}-{{
+                >{{ minNutritionAmount }}〜{{
                   maxNutritionAmount
                 }}の範囲で調整してください</mat-error
               ></mat-form-field
@@ -492,7 +492,7 @@
                   setSugarControl.hasError('min') ||
                   setSugarControl.hasError('max')
                 "
-                >{{ minNutritionAmount }}-{{
+                >{{ minNutritionAmount }}〜{{
                   maxNutritionAmount
                 }}の範囲で調整してください</mat-error
               ></mat-form-field

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -248,9 +248,12 @@
         *ngIf="preFoods && preFoods.length > 0; else noFood"
         [style.color]="preFoods.length === arrayLimit ? '#E25241' : '#000'"
       >
-        選択中<span
-          class="foods__validation"
-          *ngIf="preFoods.length === arrayLimit"
+        <span
+          [matBadge]="preFoods?.length || ''"
+          [matBadgeColor]="preFoods?.length !== arrayLimit ? 'primary' : 'warn'"
+          matBadgeOverlap="false"
+          >選択中</span
+        ><span class="foods__validation" *ngIf="preFoods?.length === arrayLimit"
           >これ以上選択できません</span
         >
       </h2>

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -242,51 +242,80 @@
         </mat-tab-group>
       </div>
 
-      <h2
-        *ngIf="preFoods && preFoods.length > 0; else noFood"
-        [style.color]="preFoods.length === arrayLimit ? '#E25241' : '#000'"
+      <ng-template #noFood
+        ><h2 class="foods__no-choice-title">
+          *食べ物を選択してください
+        </h2></ng-template
       >
-        <span
-          [matBadge]="preFoods?.length || ''"
-          [matBadgeColor]="preFoods?.length !== arrayLimit ? 'primary' : 'warn'"
-          matBadgeOverlap="false"
-          >選択中</span
-        ><span class="foods__validation" *ngIf="preFoods?.length === arrayLimit"
-          >これ以上選択できません</span
-        >
-      </h2>
-      <ng-template #noFood><h2>*食べ物を選択してください</h2></ng-template>
-      <div class="foods foods--choice">
-        <div class="food" *ngFor="let food of preFoods; let i = index">
-          <div class="food__name">
-            <p class="food__name--with-amount">
-              {{ food.food ? food.food.foodName : food.recipe.recipeTitle }}
-            </p>
-            <span class="food__amountper">
-              {{
-                food.food
-                  ? food.food.foodCalPerAmount
-                  : food.recipe.recipeCal || 0
-              }}kcal/{{ food.food ? food.food.unit : 'セット' }}
-            </span>
-          </div>
-          <div class="food__row">
-            <p>{{ food.amount }}</p>
-            <span>{{ food.food ? food.food.unit : 'セット' }}</span>
-            <p class="spacer"></p>
-            <p class="food__cal"></p>
 
-            <button
-              mat-icon-button
-              color="warn"
-              type="button"
-              (click)="removeFood(i, food)"
+      <mat-accordion
+        class="mat-accordion"
+        *ngIf="preFoods && preFoods.length > 0; else noFood"
+      >
+        <mat-expansion-panel
+          (opened)="panelOpenState = true"
+          (closed)="panelOpenState = false"
+          [expanded]="panelOpenState"
+          class="mat-elevation-z0"
+        >
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              <h2
+                class="foods__choice-title"
+                [style.color]="
+                  preFoods.length === arrayLimit ? '#E25241' : '#000'
+                "
+              >
+                <span
+                  [matBadge]="preFoods?.length || ''"
+                  [matBadgeColor]="
+                    preFoods?.length !== arrayLimit ? 'primary' : 'warn'
+                  "
+                  matBadgeOverlap="false"
+                  >選択中</span
+                >
+              </h2>
+            </mat-panel-title>
+            <mat-panel-description
+              class="foods__validation"
+              *ngIf="preFoods?.length === arrayLimit"
             >
-              <mat-icon>clear</mat-icon>
-            </button>
+              これ以上選択できません
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+          <div class="foods foods--choice">
+            <div class="food" *ngFor="let food of preFoods; let i = index">
+              <div class="food__name">
+                <p class="food__name--with-amount">
+                  {{ food.food ? food.food.foodName : food.recipe.recipeTitle }}
+                </p>
+                <span class="food__amountper">
+                  {{
+                    food.food
+                      ? food.food.foodCalPerAmount
+                      : food.recipe.recipeCal || 0
+                  }}kcal/{{ food.food ? food.food.unit : 'セット' }}
+                </span>
+              </div>
+              <div class="food__row">
+                <p>{{ food.amount }}</p>
+                <span>{{ food.food ? food.food.unit : 'セット' }}</span>
+                <p class="spacer"></p>
+                <p class="food__cal"></p>
+
+                <button
+                  mat-icon-button
+                  color="warn"
+                  type="button"
+                  (click)="removeFood(i, food)"
+                >
+                  <mat-icon>clear</mat-icon>
+                </button>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        </mat-expansion-panel>
+      </mat-accordion>
 
       <h2>栄養素</h2>
       <div class="nutrition">

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -23,6 +23,7 @@
             formControlName="setTitle"
             class="title__input"
             type="text"
+            autocomplete="off"
             required
           />
           <mat-error *ngIf="titleControl.hasError('required')"

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -1,16 +1,14 @@
 <form [formGroup]="form" (ngSubmit)="submit()">
   <div class="head">
-    <button type="button" mat-icon-button (click)="backToMenu()">
+    <button
+      type="button"
+      class="head__clear-button"
+      mat-icon-button
+      (click)="backToMenu()"
+    >
       <mat-icon>clear</mat-icon>
     </button>
     <h1>マイセット{{ title || '作成' }}画面</h1>
-    <button
-      mat-raised-button
-      color="primary"
-      [disabled]="form.invalid || preFoods.length === 0"
-    >
-      保存
-    </button>
   </div>
   <div class="container">
     <div class="editor-wrap">
@@ -473,6 +471,14 @@
           </div>
         </div>
       </div>
+      <button
+        mat-raised-button
+        color="primary"
+        class="submit-button"
+        [disabled]="form.invalid || preFoods?.length === 0 || form.pristine"
+      >
+        保存
+      </button>
     </div>
   </div>
 </form>

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -25,7 +25,11 @@
             type="text"
             autocomplete="off"
             required
+            #input
           />
+          <mat-hint align="end"
+            >{{ input.value.length }}/{{ maxTitleLength }}</mat-hint
+          >
           <mat-error *ngIf="titleControl.hasError('required')"
             >必須入力です</mat-error
           >

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -138,6 +138,9 @@
                       </div>
                     </div>
                   </div>
+                  <div *ngIf="hits.length === 0">
+                    該当する食べ物はありません
+                  </div>
                 </ng-template>
               </ais-hits>
             </ais-instantsearch>

--- a/src/app/menu/set/set-editor/set-editor.component.html
+++ b/src/app/menu/set/set-editor/set-editor.component.html
@@ -105,6 +105,7 @@
                             #amount
                             type="number"
                             autocomplete="off"
+                            #amountInput
                           />
 
                           <span class="nutrition__prefix" matSuffix>{{
@@ -119,6 +120,7 @@
                           type="button"
                           color="primary"
                           (click)="addFood(amount.value, food, null)"
+                          [disabled]="!amountInput.value.length"
                         >
                           <mat-icon>add_box</mat-icon>
                         </button>

--- a/src/app/menu/set/set-editor/set-editor.component.scss
+++ b/src/app/menu/set/set-editor/set-editor.component.scss
@@ -51,6 +51,7 @@ p {
 
   &__clear-button {
     position: fixed;
+    top: 8px;
     left: 8px;
   }
 }
@@ -93,11 +94,20 @@ p {
 
   &__validation {
     margin-left: 8px;
+    display: flex;
+    align-items: center;
   }
 
-  &--choice {
-    max-height: 200px;
-    overflow: auto;
+  &__choice-title {
+    margin-bottom: 0;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    position: relative;
+  }
+
+  &__no-choice-title {
+    margin-bottom: 32px;
   }
 }
 
@@ -347,4 +357,25 @@ p {
 .submit-button {
   display: block;
   margin: 0 auto 32px;
+}
+
+mat-expansion-panel {
+  margin-bottom: 32px;
+}
+
+.mat-expansion-panel-header {
+  padding: 0;
+  padding-right: 8px;
+}
+
+:host ::ng-deep {
+  .mat-expansion-panel-body {
+    padding: 0 0 16px;
+  }
+
+  .mat-badge-medium.mat-badge-after .mat-badge-content {
+    position: absolute;
+    top: 0;
+    right: -24px;
+  }
 }

--- a/src/app/menu/set/set-editor/set-editor.component.scss
+++ b/src/app/menu/set/set-editor/set-editor.component.scss
@@ -83,7 +83,7 @@ p {
 
   mat-tab-group {
     background: #fff;
-    max-height: 480px;
+    max-height: 520px;
   }
 
   &__validation {

--- a/src/app/menu/set/set-editor/set-editor.component.scss
+++ b/src/app/menu/set/set-editor/set-editor.component.scss
@@ -39,7 +39,7 @@ p {
 
 .head {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   padding: 0 8px;
   height: 56px;
@@ -48,6 +48,11 @@ p {
   position: sticky;
   top: 0;
   background: #fff;
+
+  &__clear-button {
+    position: fixed;
+    left: 8px;
+  }
 }
 
 .title {
@@ -337,4 +342,9 @@ p {
 .more-button {
   display: flex;
   justify-content: center;
+}
+
+.submit-button {
+  display: block;
+  margin: 0 auto 32px;
 }

--- a/src/app/menu/set/set-editor/set-editor.component.ts
+++ b/src/app/menu/set/set-editor/set-editor.component.ts
@@ -20,6 +20,7 @@ import { Recipe, RecipeWithAuthor } from 'src/app/interfaces/recipe';
 import { QueryDocumentSnapshot } from '@angular/fire/firestore';
 import { Food } from 'src/app/interfaces/food';
 import { Subscription } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-set-editor',
@@ -139,7 +140,8 @@ export class SetEditorComponent implements OnInit, OnDestroy {
     private recipeService: RecipeService,
     private authService: AuthService,
     private setService: SetService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar
   ) {
     this.subscription = this.route.queryParamMap.subscribe((setId) => {
       if (setId) {
@@ -283,6 +285,9 @@ export class SetEditorComponent implements OnInit, OnDestroy {
           (this.currentDietaryFiber + recipe.recipeDietaryFiber) * 10
         ) / 10;
     }
+    this.snackBar.open('食べ物を追加しました', null, {
+      duration: 2000,
+    });
   }
 
   removeFood(index: number, food: FoodInArray) {

--- a/src/app/menu/set/set-editor/set-editor.component.ts
+++ b/src/app/menu/set/set-editor/set-editor.component.ts
@@ -37,6 +37,8 @@ export class SetEditorComponent implements OnInit, OnDestroy {
   readonly maxTitleLength = 50;
   readonly maxNutritionAmount = 5000;
   readonly minNutritionAmount = 0;
+  readonly arrayLimit = 30;
+  panelOpenState = true;
   title: string;
   config = this.searchService.config;
   myRecipes: RecipeWithAuthor[] = new Array();
@@ -52,7 +54,6 @@ export class SetEditorComponent implements OnInit, OnDestroy {
   lunch = false;
   dinner = false;
 
-  arrayLimit = 30;
   form = this.fb.group({
     setTitle: [
       '',

--- a/src/app/menu/set/set-editor/set-editor.module.ts
+++ b/src/app/menu/set/set-editor/set-editor.module.ts
@@ -14,6 +14,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatBadgeModule } from '@angular/material/badge';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 @NgModule({
   declarations: [SetEditorComponent],
@@ -31,6 +32,7 @@ import { MatBadgeModule } from '@angular/material/badge';
     MatInputModule,
     MatCheckboxModule,
     MatBadgeModule,
+    MatExpansionModule,
   ],
 })
 export class SetEditorModule {}

--- a/src/app/menu/set/set-editor/set-editor.module.ts
+++ b/src/app/menu/set/set-editor/set-editor.module.ts
@@ -13,6 +13,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatBadgeModule } from '@angular/material/badge';
 
 @NgModule({
   declarations: [SetEditorComponent],
@@ -29,6 +30,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
     MatFormFieldModule,
     MatInputModule,
     MatCheckboxModule,
+    MatBadgeModule,
   ],
 })
 export class SetEditorModule {}


### PR DESCRIPTION
fix #165 
以下の作業を作業を行いました。ご確認お願いします。

## Detail

### detailページ
- [x] 削除ボタンを灰色に変更

### editorページ
- [x] 保存ボタンの位置を下に配置
- [x] 文字数カウント常に表示
- [x] 検索結果ない時のUI
- [x] 食べ物追加UI変更
- [x] スクロールを解消する
- [x] Input 初期値0セット