### PR TITLE
食べ物登録ページUI改善 #177

### DIFF
--- a/src/app/bottom-sheet/meal-input/meal-input.component.html
+++ b/src/app/bottom-sheet/meal-input/meal-input.component.html
@@ -6,12 +6,8 @@
     }}
   </p>
 
-  <form class="food__choice">
-    <mat-form-field
-      class="food__choice-form-field"
-      [formGroup]="amountForm"
-      appearance="outline"
-    >
+  <form class="form">
+    <mat-form-field [formGroup]="amountForm" appearance="outline">
       <mat-label>数量を入力してください</mat-label>
       <input
         matInput
@@ -28,28 +24,34 @@
         data.food ? data.food.unit : 'セット'
       }}</span>
       <mat-error *ngIf="amount > data.maxAmount || amount < data.minAmount"
-        >{{ data.maxAmount }}以内で入力してください</mat-error
+        >{{ data.minAmount }}〜{{
+          data.maxAmount
+        }}の範囲でで入力してください</mat-error
       >
+      <mat-hint align="end">
+        {{
+          data.food
+            ? (data.food.foodCalPerAmount * amount | number: '1.1-1')
+            : (data.set.setCal * amount | number: '1.1-1')
+        }}kcal</mat-hint
+      >
+      <mat-error *ngIf="amountControl.hasError('required')"
+        >必須入力です
+      </mat-error>
     </mat-form-field>
   </form>
-  <div class="food-cal">
-    <dt class="food-cal__title">暫定カロリー：</dt>
-    <dd class="food-cal__amount">
-      {{
-        data.food
-          ? (data.food.foodCalPerAmount * amount | number: '1.1-1')
-          : (data.set.setCal * amount | number: '1.1-1')
-      }}
-    </dd>
-    kcal
-  </div>
 
-  <button
-    mat-stroked-button
-    color="primary"
-    (click)="addFood(amount)"
-    [disabled]="amountForm.invalid"
-  >
-    OK
-  </button>
+  <div class="nav">
+    <button mat-stroked-button (click)="bottomSheetRef.dismiss()">
+      キャンセル
+    </button>
+    <button
+      mat-stroked-button
+      color="primary"
+      (click)="addFood(amount)"
+      [disabled]="amountForm.invalid"
+    >
+      OK
+    </button>
+  </div>
 </div>

--- a/src/app/bottom-sheet/meal-input/meal-input.component.scss
+++ b/src/app/bottom-sheet/meal-input/meal-input.component.scss
@@ -8,6 +8,10 @@
   align-items: center;
 }
 
+.form {
+  margin-bottom: 16px;
+}
+
 .choice-input {
   text-align: right;
 }
@@ -24,14 +28,8 @@
   margin-bottom: 24px;
 }
 
-.food-cal {
-  width: 100%;
+.nav {
   display: flex;
-  justify-content: center;
-  gap: 32px;
-  margin-bottom: 24px;
-
-  &__amount {
-    margin: 0;
-  }
+  gap: 8px;
+  margin-bottom: 8px;
 }

--- a/src/app/bottom-sheet/meal-input/meal-input.component.ts
+++ b/src/app/bottom-sheet/meal-input/meal-input.component.ts
@@ -22,6 +22,7 @@ export class MealInputComponent implements OnInit {
       [
         Validators.min(this.data.minAmount),
         Validators.max(this.data.maxAmount),
+        Validators.required,
       ],
     ],
   });
@@ -40,7 +41,7 @@ export class MealInputComponent implements OnInit {
     },
     private dailyInfoService: DailyInfoService,
     private fb: FormBuilder,
-    private bottomSheetRef: MatBottomSheetRef<MealInputComponent>
+    public bottomSheetRef: MatBottomSheetRef<MealInputComponent>
   ) {}
 
   addFood(amount: number) {

--- a/src/app/editor-meal/editor-meal/editor-meal.component.html
+++ b/src/app/editor-meal/editor-meal/editor-meal.component.html
@@ -1,7 +1,4 @@
 <div class="edtor-meal">
-  <button class="back" routerLink="/" mat-stroked-button>
-    <mat-icon>navigate_before</mat-icon>TOP
-  </button>
   <div class="tabs">
     <nav
       mat-tab-nav-bar

--- a/src/app/editor-meal/fav-foods/fav-foods.component.html
+++ b/src/app/editor-meal/fav-foods/fav-foods.component.html
@@ -71,14 +71,16 @@
                 type="number"
               />
               <span matSuffix>{{ food.unit }}</span>
+              <mat-hint align="end">
+                {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
+                kcal</mat-hint
+              >
               <mat-error *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
-                >入力範囲{{ minAmount }}-{{ maxAmount }}</mat-error
+                >{{ minAmount }}〜{{
+                  maxAmount
+                }}の範囲で入力してください</mat-error
               >
             </mat-form-field>
-            <p class="food__cal">
-              {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
-              kcal
-            </p>
           </div>
         </form>
 
@@ -97,6 +99,7 @@
           color="primary"
           (click)="addFood(amount[i], food)"
           [disabled]="
+            amount[i] === null ||
             amount[i] > maxAmount ||
             amount[i] < minAmount ||
             selectedMealsNum >= maxSelectNum

--- a/src/app/editor-meal/fav-foods/fav-foods.component.html
+++ b/src/app/editor-meal/fav-foods/fav-foods.component.html
@@ -53,27 +53,33 @@
         </div>
         <div class="spacer"></div>
         <form class="food__choice" [formGroup]="amountForm">
-          <mat-form-field class="food__choice-form-field" appearance="outline">
-            <input
-              matInput
-              class="food__choice-input"
-              autocomplete="off"
-              formControlName="amount"
-              [max]="maxAmount"
-              [min]="minAmount"
-              step="0.1"
-              [(ngModel)]="amount[i]"
-              type="number"
-            />
-            <span matSuffix>{{ food.unit }}</span>
-            <mat-error *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
-              >入力範囲{{ minAmount }}-{{ maxAmount }}</mat-error
+          <div formArrayName="amountArray">
+            <mat-form-field
+              class="food__choice-form-field"
+              appearance="outline"
+              [formGroupName]="i"
             >
-          </mat-form-field>
-          <p class="food__cal">
-            {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
-            kcal
-          </p>
+              <input
+                matInput
+                class="food__choice-input"
+                autocomplete="off"
+                [formControlName]="i"
+                [max]="maxAmount"
+                [min]="minAmount"
+                step="0.1"
+                [(ngModel)]="amount[i]"
+                type="number"
+              />
+              <span matSuffix>{{ food.unit }}</span>
+              <mat-error *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
+                >入力範囲{{ minAmount }}-{{ maxAmount }}</mat-error
+              >
+            </mat-form-field>
+            <p class="food__cal">
+              {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
+              kcal
+            </p>
+          </div>
         </form>
 
         <button

--- a/src/app/editor-meal/fav-foods/fav-foods.component.scss
+++ b/src/app/editor-meal/fav-foods/fav-foods.component.scss
@@ -2,7 +2,7 @@
   display: flex;
   background: #fff;
   align-items: center;
-  padding: 8px 0;
+  padding: 16px 0;
 
   &__fav {
     margin: 0 8px 0 0px;

--- a/src/app/editor-meal/food-search/food-search.component.html
+++ b/src/app/editor-meal/food-search/food-search.component.html
@@ -63,16 +63,18 @@
                     [(ngModel)]="amount[i]"
                     type="number"
                   />
+                  <mat-hint align="end">
+                    {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
+                    kcal</mat-hint
+                  >
                   <span matSuffix>{{ food.unit }}</span>
                   <mat-error
                     *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
-                    >{{ maxAmount }}以内で入力してください</mat-error
+                    >{{ minAmount }}〜{{
+                      maxAmount
+                    }}の範囲で入力してください</mat-error
                   >
                 </mat-form-field>
-                <p class="food__cal">
-                  {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
-                  kcal
-                </p>
               </div>
             </form>
 
@@ -92,6 +94,7 @@
               color="primary"
               (click)="addFood(amount[i], food)"
               [disabled]="
+                amount[i] === null ||
                 amount[i] > maxAmount ||
                 amount[i] < minAmount ||
                 selectedMealsNum >= maxSelectNum

--- a/src/app/editor-meal/food-search/food-search.component.html
+++ b/src/app/editor-meal/food-search/food-search.component.html
@@ -45,32 +45,35 @@
             </div>
             <div class="spacer"></div>
 
-            <form class="food__choice" [formGroup]="amountForm">
-              <mat-form-field
-                class="food__choice-form-field"
-                appearance="outline"
-              >
-                <input
-                  matInput
-                  class="food__choice-input"
-                  autocomplete="off"
-                  formControlName="amount"
-                  [max]="maxAmount"
-                  [min]="minAmount"
-                  step="0.1"
-                  [(ngModel)]="amount[i]"
-                  type="number"
-                />
-                <span matSuffix>{{ food.unit }}</span>
-                <mat-error
-                  *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
-                  >{{ maxAmount }}以内で入力してください</mat-error
+            <form [formGroup]="amountForm">
+              <div class="food__choice" formArrayName="amountArray">
+                <mat-form-field
+                  class="food__choice-form-field"
+                  appearance="outline"
+                  [formGroupName]="i"
                 >
-              </mat-form-field>
-              <p class="food__cal">
-                {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
-                kcal
-              </p>
+                  <input
+                    matInput
+                    class="food__choice-input"
+                    autocomplete="off"
+                    [formControlName]="i"
+                    [max]="maxAmount"
+                    [min]="minAmount"
+                    step="0.1"
+                    [(ngModel)]="amount[i]"
+                    type="number"
+                  />
+                  <span matSuffix>{{ food.unit }}</span>
+                  <mat-error
+                    *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
+                    >{{ maxAmount }}以内で入力してください</mat-error
+                  >
+                </mat-form-field>
+                <p class="food__cal">
+                  {{ food.foodCalPerAmount * amount[i] | number: '1.1-1' }}
+                  kcal
+                </p>
+              </div>
             </form>
 
             <button

--- a/src/app/editor-meal/food-search/food-search.component.html
+++ b/src/app/editor-meal/food-search/food-search.component.html
@@ -45,8 +45,8 @@
             </div>
             <div class="spacer"></div>
 
-            <form [formGroup]="amountForm">
-              <div class="food__choice" formArrayName="amountArray">
+            <form class="food__choice" [formGroup]="amountForm">
+              <div formArrayName="amountArray">
                 <mat-form-field
                   class="food__choice-form-field"
                   appearance="outline"

--- a/src/app/editor-meal/food-search/food-search.component.scss
+++ b/src/app/editor-meal/food-search/food-search.component.scss
@@ -11,7 +11,7 @@
 .food {
   display: flex;
   align-items: center;
-  padding: 8px 0;
+  padding: 16px 0;
 
   &__fav {
     margin: 0 8px 0 0px;

--- a/src/app/editor-meal/food-search/food-search.component.ts
+++ b/src/app/editor-meal/food-search/food-search.component.ts
@@ -8,12 +8,7 @@ import { Food } from 'src/app/interfaces/food';
 import { DailyMeal } from 'src/app/interfaces/daily-info';
 import { Subscription } from 'rxjs';
 import { AverageService } from 'src/app/services/average.service';
-import {
-  FormControl,
-  Validators,
-  FormBuilder,
-  FormArray,
-} from '@angular/forms';
+import { Validators, FormBuilder, FormArray } from '@angular/forms';
 import { QueryDocumentSnapshot } from '@angular/fire/firestore';
 import { take } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -35,20 +30,11 @@ export class FoodSearchComponent implements OnInit, OnDestroy {
   readonly minAmount = 0;
   readonly maxAmount = 10000;
   selectedMealsNum: number;
-  amount = [].fill(0);
+  amount = new Array(10).fill(0);
   isLikedlist: string[] = new Array();
   config = this.searchService.config;
   amountForm = this.fb.group({
     amountArray: this.fb.array([]),
-    // 1: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 2: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 3: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 4: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 5: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 6: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 7: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 8: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
-    // 9: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
   });
   get amountArray(): FormArray {
     return this.amountForm.get('amountArray') as FormArray;
@@ -136,10 +122,6 @@ export class FoodSearchComponent implements OnInit, OnDestroy {
         this.date,
         'food'
       );
-    } else {
-      this.snackBar.open('数値を入力してください', null, {
-        duration: 2000,
-      });
     }
   }
 

--- a/src/app/editor-meal/food-search/food-search.component.ts
+++ b/src/app/editor-meal/food-search/food-search.component.ts
@@ -8,7 +8,12 @@ import { Food } from 'src/app/interfaces/food';
 import { DailyMeal } from 'src/app/interfaces/daily-info';
 import { Subscription } from 'rxjs';
 import { AverageService } from 'src/app/services/average.service';
-import { FormControl, Validators, FormBuilder } from '@angular/forms';
+import {
+  FormControl,
+  Validators,
+  FormBuilder,
+  FormArray,
+} from '@angular/forms';
 import { QueryDocumentSnapshot } from '@angular/fire/firestore';
 import { take } from 'rxjs/operators';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -34,13 +39,19 @@ export class FoodSearchComponent implements OnInit, OnDestroy {
   isLikedlist: string[] = new Array();
   config = this.searchService.config;
   amountForm = this.fb.group({
-    amount: [
-      0,
-      [Validators.min(this.minAmount), Validators.max(this.maxAmount)],
-    ],
+    amountArray: this.fb.array([]),
+    // 1: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 2: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 3: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 4: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 5: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 6: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 7: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 8: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
+    // 9: [0, [Validators.min(this.minAmount), Validators.max(this.maxAmount)]],
   });
-  get amountControl(): FormControl {
-    return this.amountForm.get('amount') as FormControl;
+  get amountArray(): FormArray {
+    return this.amountForm.get('amountArray') as FormArray;
   }
 
   constructor(
@@ -59,6 +70,7 @@ export class FoodSearchComponent implements OnInit, OnDestroy {
     const routeSub = this.route.queryParamMap.subscribe((paramMaps) => {
       this.date = paramMaps.get('date');
       this.getFavFoods();
+      this.setFormArray();
     });
 
     const selectedSub = this.getSelectedMeals();
@@ -71,6 +83,17 @@ export class FoodSearchComponent implements OnInit, OnDestroy {
     this.subscription.add(routeSub);
     this.subscription.add(selectedSub);
     this.subscription.add(routerSub);
+  }
+  private setFormArray() {
+    for (let i = 0; i < 10; i++) {
+      const amountGroup = this.fb.group({
+        [i]: [
+          0,
+          [Validators.min(this.minAmount), Validators.max(this.maxAmount)],
+        ],
+      });
+      this.amountArray.push(amountGroup);
+    }
   }
 
   private getFavFoods() {

--- a/src/app/editor-meal/my-set/my-set.component.html
+++ b/src/app/editor-meal/my-set/my-set.component.html
@@ -57,27 +57,33 @@
         <div class="spacer"></div>
 
         <form class="food__choice" [formGroup]="amountForm">
-          <mat-form-field class="food__choice-form-field" appearance="outline">
-            <input
-              matInput
-              class="food__choice-input"
-              autocomplete="off"
-              formControlName="amount"
-              [max]="maxAmount"
-              [min]="minAmount"
-              step="0.1"
-              [(ngModel)]="amount[i]"
-              type="number"
-            />
-            <span matSuffix>セット</span>
-            <mat-error *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
-              >入力範囲{{ minAmount }}-{{ maxAmount }}</mat-error
+          <div formArrayName="amountArray">
+            <mat-form-field
+              class="food__choice-form-field"
+              appearance="outline"
+              [formGroupName]="i"
             >
-          </mat-form-field>
-          <p class="food__cal">
-            {{ set.setCal * amount[i] | number: '1.1-1' }}
-            kcal
-          </p>
+              <input
+                matInput
+                class="food__choice-input"
+                autocomplete="off"
+                [formControlName]="i"
+                [max]="maxAmount"
+                [min]="minAmount"
+                step="0.1"
+                [(ngModel)]="amount[i]"
+                type="number"
+              />
+              <span matSuffix>セット</span>
+              <mat-error *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
+                >入力範囲{{ minAmount }}-{{ maxAmount }}</mat-error
+              >
+            </mat-form-field>
+            <!-- <p class="food__cal">
+              {{ set.setCal * amount[i] | number: '1.1-1' }}
+              kcal
+            </p> -->
+          </div>
         </form>
 
         <button
@@ -95,6 +101,7 @@
           color="primary"
           (click)="addSet(amount[i], set)"
           [disabled]="
+            amount[i] === null ||
             amount[i] > maxAmount ||
             amount[i] < minAmount ||
             selectedMealsNum >= maxSelectNum

--- a/src/app/editor-meal/my-set/my-set.component.html
+++ b/src/app/editor-meal/my-set/my-set.component.html
@@ -75,14 +75,15 @@
                 type="number"
               />
               <span matSuffix>セット</span>
+              <mat-hint align="end">
+                {{ set.setCal * amount[i] | number: '1.1-1' }} kcal</mat-hint
+              >
               <mat-error *ngIf="amount[i] > maxAmount || amount[i] < minAmount"
-                >入力範囲{{ minAmount }}-{{ maxAmount }}</mat-error
+                >{{ minAmount }}〜{{
+                  maxAmount
+                }}の範囲で入力してください</mat-error
               >
             </mat-form-field>
-            <!-- <p class="food__cal">
-              {{ set.setCal * amount[i] | number: '1.1-1' }}
-              kcal
-            </p> -->
           </div>
         </form>
 

--- a/src/app/editor-meal/my-set/my-set.component.scss
+++ b/src/app/editor-meal/my-set/my-set.component.scss
@@ -1,7 +1,7 @@
 .food {
   display: flex;
   align-items: center;
-  padding: 8px 0;
+  padding: 16px 0;
 
   &__book {
     margin: 0 8px 0 0px;

--- a/src/app/editor-meal/my-set/my-set.component.scss
+++ b/src/app/editor-meal/my-set/my-set.component.scss
@@ -42,6 +42,7 @@
   &__choice-form-field {
     font-size: 14px;
     margin-bottom: 4px;
+    width: 100%;
   }
 
   &__choice-input {

--- a/src/app/editor-meal/my-set/my-set.component.ts
+++ b/src/app/editor-meal/my-set/my-set.component.ts
@@ -118,10 +118,6 @@ export class MySetComponent implements OnInit, OnDestroy {
         this.date,
         'set'
       );
-    } else {
-      this.snackBar.open('数値を入力してください', null, {
-        duration: 2000,
-      });
     }
   }
 

--- a/src/app/editor-meal/my-set/my-set.component.ts
+++ b/src/app/editor-meal/my-set/my-set.component.ts
@@ -7,7 +7,7 @@ import { DailyInfoService } from 'src/app/services/daily-info.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { SetService } from 'src/app/services/set.service';
 import { AverageService } from 'src/app/services/average.service';
-import { Validators, FormControl, FormBuilder } from '@angular/forms';
+import { Validators, FormBuilder, FormArray } from '@angular/forms';
 import { QueryDocumentSnapshot } from '@angular/fire/firestore';
 import { take } from 'rxjs/operators';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
@@ -25,25 +25,23 @@ export class MySetComponent implements OnInit, OnDestroy {
   private subscription = new Subscription();
   private date: string;
   private meal: string;
+  private count = 0;
 
   readonly maxSelectNum = 50;
   readonly minAmount = 0;
   readonly maxAmount = 100;
   readonly getNumber = 10;
   selectedMealsNum: number;
-  amount = [].fill(0);
+  amount = new Array(10).fill(0);
   sets: Set[] = new Array();
   isNext: boolean;
   loading: boolean;
 
   amountForm = this.fb.group({
-    amount: [
-      0,
-      [Validators.min(this.minAmount), Validators.max(this.maxAmount)],
-    ],
+    amountArray: this.fb.array([]),
   });
-  get amountControl(): FormControl {
-    return this.amountForm.get('amount') as FormControl;
+  get amountArray(): FormArray {
+    return this.amountForm.get('amountArray') as FormArray;
   }
   constructor(
     private route: ActivatedRoute,
@@ -73,8 +71,23 @@ export class MySetComponent implements OnInit, OnDestroy {
     this.subscription.add(routerSub);
   }
 
+  private setFormArray(count: number) {
+    const minCount = count * 10;
+    for (let i = minCount; i < minCount + 10; i++) {
+      const amountGroup = this.fb.group({
+        [i]: [
+          0,
+          [Validators.min(this.minAmount), Validators.max(this.maxAmount)],
+        ],
+      });
+      this.amountArray.push(amountGroup);
+    }
+    this.count++;
+  }
+
   getSets() {
     this.loading = true;
+    this.setFormArray(this.count);
     this.setService
       .getSets(this.authService.uid, this.getNumber, this.lastDoc, this.meal)
       .pipe(take(1))

--- a/src/app/editor-meal/selected-foods/selected-foods.component.html
+++ b/src/app/editor-meal/selected-foods/selected-foods.component.html
@@ -55,13 +55,10 @@
       <div class="food">
         <div class="food__wrap">
           <p class="food__name">
-            {{
-              foodOrSet.food ? foodOrSet.food.foodName : foodOrSet.set.setTitle
-            }}
+            {{ foodOrSet.food?.foodName || foodOrSet.set.setTitle }}
           </p>
           <p class="food__selected-amount">
-            {{ foodOrSet.amount
-            }}{{ foodOrSet.food ? foodOrSet.food.unit : 'セット' }}
+            {{ foodOrSet.amount || 0 }}{{ foodOrSet.food?.unit || 'セット' }}
           </p>
         </div>
         <div class="spacer"></div>
@@ -69,9 +66,8 @@
           <p class="food__cal">
             {{
               foodOrSet.amount *
-                (foodOrSet.food
-                  ? foodOrSet.food.foodCalPerAmount
-                  : foodOrSet.set.setCal) | number: '1.1-1'
+                (foodOrSet.food?.foodCalPerAmount || foodOrSet.set.setCal)
+                | number: '1.1-1'
             }}
             kcal
           </p>
@@ -84,9 +80,7 @@
             deleteMeal(
               foodOrSet.mealId,
               foodOrSet.amount,
-              foodOrSet.food
-                ? foodOrSet.food.foodCalPerAmount
-                : foodOrSet.set.setCal
+              foodOrSet.food?.foodCalPerAmount || foodOrSet.set.setCal
             )
           "
         >


### PR DESCRIPTION
fix #177 
以下の作業を行いました。ご確認お願いします。

## Detail
- [x] 各食べ物の上下の項目にスペースをいれる
- [x] mat-hintに 現在のカロリー値を表示
- [x] mat-error連動させない
- [x] TOPへの戻るボタン削除
- [x] selectページリファクタ
