### PR TITLE
レシピページ リファクタリング/機能改善 #174

### DIFF
--- a/src/app/menu/recipe/recipe-detail/recipe-detail.component.html
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.component.html
@@ -19,7 +19,7 @@
         *ngIf="recipe.authorId === userId"
         mat-icon-button
         class="delete-button"
-        (click)="openDeleteDialog()"
+        (click)="openDeleteDialog(recipe.recipeId)"
       >
         <mat-icon>delete</mat-icon>
       </button>

--- a/src/app/menu/recipe/recipe-detail/recipe-detail.component.html
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.component.html
@@ -44,7 +44,7 @@
       </figure>
       <div class="content-head">
         <h2 class="content__name">レシピ名</h2>
-        <h4 *ngIf="recipe.public ? true : false">
+        <h4 *ngIf="recipe.public">
           公開中
         </h4>
       </div>
@@ -89,14 +89,14 @@
         <div class="nutrition__detail">
           <h3 class="nutrition__name">総カロリー</h3>
           <p>
-            {{ recipe.recipeCal ? recipe.recipeCal : '未入力' }}
+            {{ recipe.recipeCal || '未入力' }}
             <span *ngIf="recipe.recipeCal">kcal</span>
           </p>
         </div>
         <div class="nutrition__detail">
           <h3 class="nutrition__name">タンパク質</h3>
           <p>
-            {{ recipe.recipeProtein ? recipe.recipeProtein : '未入力' }}
+            {{ recipe.recipeProtein || '未入力' }}
             <span *ngIf="recipe.recipeProtein">g</span>
           </p>
         </div>
@@ -105,7 +105,7 @@
             脂質
           </h3>
           <p>
-            {{ recipe.recipeFat ? recipe.recipeFat : '未入力' }}
+            {{ recipe.recipeFat || '未入力' }}
             <span *ngIf="recipe.recipeFat">g</span>
           </p>
         </div>
@@ -114,7 +114,7 @@
             糖質
           </h3>
           <p>
-            {{ recipe.recipeSugar ? recipe.recipeSugar : '未入力' }}
+            {{ recipe.recipeSugar || '未入力' }}
             <span *ngIf="recipe.recipeSugar">g</span>
           </p>
         </div>
@@ -123,9 +123,7 @@
             食物繊維
           </h3>
           <p>
-            {{
-              recipe.recipeDietaryFiber ? recipe.recipeDietaryFiber : '未入力'
-            }}
+            {{ recipe.recipeDietaryFiber || '未入力' }}
             <span *ngIf="recipe.recipeDietaryFiber">g</span>
           </p>
         </div>
@@ -134,11 +132,7 @@
             炭水化物
           </h3>
           <p>
-            {{
-              recipe.recipeTotalCarbohydrate
-                ? recipe.recipeTotalCarbohydrate
-                : '未入力'
-            }}
+            {{ recipe.recipeTotalCarbohydrate || '未入力' }}
             <span *ngIf="recipe.recipeTotalCarbohydrate">g</span>
           </p>
         </div>

--- a/src/app/menu/recipe/recipe-detail/recipe-detail.component.ts
+++ b/src/app/menu/recipe/recipe-detail/recipe-detail.component.ts
@@ -1,55 +1,44 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { RecipeService } from 'src/app/services/recipe.service';
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Recipe } from 'src/app/interfaces/recipe';
 import { AuthService } from 'src/app/services/auth.service';
 import { MatDialog } from '@angular/material/dialog';
 import { DeleteDialogComponent } from 'src/app/dialogs/delete-dialog/delete-dialog.component';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-recipe-detail',
   templateUrl: './recipe-detail.component.html',
   styleUrls: ['./recipe-detail.component.scss'],
 })
-export class RecipeDetailComponent implements OnInit, OnDestroy {
-  private subscription = new Subscription();
-
+export class RecipeDetailComponent implements OnInit {
   readonly userId = this.authService.uid;
-  recipe$: Observable<Recipe>;
-  query: string;
+
+  recipe$: Observable<Recipe> = this.route.queryParamMap.pipe(
+    switchMap((queryParams) =>
+      this.recipeService.getRecipeByRecipeId(queryParams.get('id'))
+    )
+  );
 
   constructor(
     private route: ActivatedRoute,
     private recipeService: RecipeService,
     private authService: AuthService,
     private dialog: MatDialog
-  ) {
-    this.getRecipe();
-  }
+  ) {}
 
-  private getRecipe() {
-    const recipeSub = this.route.queryParamMap.subscribe((recipeId) => {
-      this.query = recipeId.get('id');
-      this.recipe$ = this.recipeService.getRecipeByRecipeId(this.query);
-    });
-    this.subscription.add(recipeSub);
-  }
-
-  openDeleteDialog(): void {
+  openDeleteDialog(recipeId: string): void {
     this.dialog.open(DeleteDialogComponent, {
       width: '80%',
       maxWidth: '400px',
       data: {
-        recipeId: this.query,
+        recipeId,
         title: 'レシピ',
       },
     });
   }
 
   ngOnInit(): void {}
-
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
-  }
 }

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.html
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.html
@@ -8,7 +8,7 @@
         type="button"
         mat-icon-button
         class="clear-button"
-        (click)="back()"
+        (click)="backToPage()"
       >
         <mat-icon>clear</mat-icon>
       </button>
@@ -45,7 +45,7 @@
             #thumbnail
             class="title__image-form"
             type="file"
-            (change)="thumbnailDialog($event)"
+            (change)="openThumbnailDialog($event)"
             accept=".png, .jpg, .jpeg"
           />
           <button
@@ -269,7 +269,7 @@
               >
                 <input
                   #processImage
-                  (change)="processImageDialog($event, i)"
+                  (change)="openProcessImageDialog($event, i)"
                   class="process__image-form"
                   type="file"
                   accept=".png, .jpg, .jpeg"

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.html
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.html
@@ -2,7 +2,7 @@
   <mat-spinner class="loading__spinner" diameter="30"></mat-spinner>
 </div>
 <div *ngIf="!loading">
-  <form [formGroup]="form" (ngSubmit)="updateRecipe()">
+  <form [formGroup]="form" (ngSubmit)="submitRecipe()">
     <div class="head">
       <button
         type="button"

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
@@ -189,7 +189,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.loading = false;
   }
 
-  addIngredinet() {
+  addIngredinet(): void {
     const ingredientFormGroup = this.fb.group({
       name: [
         '',
@@ -210,7 +210,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.dataSource.next(this.ingredients.controls);
   }
 
-  editIngredient() {
+  editIngredient(): void {
     if (!this.ingredient) {
       this.ingredient = true;
       this.displayedColumns.push('delete');
@@ -220,7 +220,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     }
   }
 
-  removeIngredinet(index: number) {
+  removeIngredinet(index: number): void {
     this.ingredients.removeAt(index);
     if (this.ingredients.length === 0) {
       this.ingredient = false;
@@ -229,7 +229,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.dataSource.next(this.ingredients.controls);
   }
 
-  addProcess() {
+  addProcess(): void {
     const processFormGroup = this.fb.group({
       description: [
         '',
@@ -241,7 +241,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.processSource.next(this.processes.controls);
   }
 
-  editProcess() {
+  editProcess(): void {
     if (!this.process) {
       this.process = true;
       this.displayedColumnsProcess.push('delete');
@@ -251,7 +251,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     }
   }
 
-  removeProcess(index: number) {
+  removeProcess(index: number): void {
     this.processes.removeAt(index);
     this.processURLs.splice(index, 1);
     if (this.processes.length === 0) {
@@ -261,7 +261,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.processSource.next(this.processes.controls);
   }
 
-  thumbnailDialog(event) {
+  openThumbnailDialog(event): void {
     const imageFile: File = event.target.files[0];
     if (imageFile) {
       const dialogRef = this.dialog.open(RecipeThumbnailComponent, {
@@ -280,7 +280,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.thumbnailInput.nativeElement.value = '';
   }
 
-  processImageDialog(event, index) {
+  openProcessImageDialog(event, index): void {
     const imageFile: File = event.target.files[0];
     if (imageFile) {
       const dialogRef = this.dialog.open(RecipeProcessImageComponent, {
@@ -299,14 +299,14 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.processImageInput.nativeElement.value = '';
   }
 
-  back(): void {
+  backToPage(): void {
     if (this.isCreating) {
-      this.deleteImage();
+      this.submitToDeleteImage();
     }
     this.location.back();
   }
 
-  changePublic() {
+  changePublic(): void {
     if (this.public) {
       this.public = false;
     } else {
@@ -314,7 +314,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     }
   }
 
-  submitRecipe() {
+  submitRecipe(): void {
     const formData = this.form.value;
     const sendProcesses: ProcessOfRecipe[] = this.processURLs.map(
       (v, index) => {
@@ -349,7 +349,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     this.location.back();
   }
 
-  deleteImage() {
+  submitToDeleteImage(): void {
     this.recipeService.deleteUpdatedImage(this.userId, this.recipeId);
   }
 

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
@@ -23,6 +23,7 @@ import { RecipeService } from 'src/app/services/recipe.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { ProcessOfRecipe } from 'src/app/interfaces/recipe';
+
 @Component({
   selector: 'app-recipe-editor',
   templateUrl: './recipe-editor.component.html',
@@ -325,47 +326,39 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     }
   }
 
-  updateRecipe() {
+  submitRecipe() {
     const formData = this.form.value;
     const sendProcesses: ProcessOfRecipe[] = this.processURLs.map(
       (v, index) => {
         return { ...formData.processes[index], photoURL: v };
       }
     );
+    const recipeDataExcludeRecipeId = {
+      recipeTitle: formData.recipeTitle,
+      recipeThumbnailURL: this.thumbnailURL,
+      recipeDescription: formData.recipeDescription,
+      recipeCal: formData.recipeCal,
+      recipeProtein: formData.recipeProtein,
+      recipeFat: formData.recipeFat,
+      recipeTotalCarbohydrate: formData.recipeTotalCarbohydrate,
+      recipeDietaryFiber: formData.recipeDietaryFiber,
+      recipeSugar: formData.recipeSugar,
+      public: this.public,
+      authorId: this.userId,
+      foods: formData.ingredients,
+      processes: sendProcesses,
+    };
     if (this.query) {
       this.recipeService.updateRecipe({
         recipeId: this.query,
-        recipeTitle: formData.recipeTitle,
-        recipeThumbnailURL: this.thumbnailURL,
-        recipeDescription: formData.recipeDescription,
-        recipeCal: formData.recipeCal,
-        recipeProtein: formData.recipeProtein,
-        recipeFat: formData.recipeFat,
-        recipeTotalCarbohydrate: formData.recipeTotalCarbohydrate,
-        recipeDietaryFiber: formData.recipeDietaryFiber,
-        recipeSugar: formData.recipeSugar,
-        public: this.public,
-        authorId: this.userId,
-        foods: formData.ingredients,
-        processes: sendProcesses,
+        ...recipeDataExcludeRecipeId,
       });
     } else {
       this.recipeService.createRecipe({
-        recipeTitle: formData.recipeTitle,
-        recipeThumbnailURL: this.thumbnailURL,
-        recipeDescription: formData.recipeDescription,
-        recipeCal: formData.recipeCal,
-        recipeProtein: formData.recipeProtein,
-        recipeFat: formData.recipeFat,
-        recipeTotalCarbohydrate: formData.recipeTotalCarbohydrate,
-        recipeDietaryFiber: formData.recipeDietaryFiber,
-        recipeSugar: formData.recipeSugar,
-        public: this.public,
-        authorId: this.userId,
-        foods: formData.ingredients,
-        processes: sendProcesses,
+        ...recipeDataExcludeRecipeId,
       });
     }
+    this.location.back();
   }
 
   deleteImage() {

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
@@ -23,7 +23,7 @@ import { RecipeService } from 'src/app/services/recipe.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
 import { ProcessOfRecipe, Recipe } from 'src/app/interfaces/recipe';
-import { map, switchMap } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-recipe-editor',

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
@@ -50,7 +50,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
   ingredient = false;
   process = false;
   public = false;
-  loading: boolean;
+  loading = true;
   isCreating: boolean;
 
   form = this.fb.group({
@@ -154,7 +154,6 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     private recipeService: RecipeService,
     private authService: AuthService
   ) {
-    this.loading = true;
     this.getRecipe();
   }
 

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
@@ -36,11 +36,12 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
 
   private readonly userId = this.authService.uid;
   private subscription = new Subscription();
-  private recipeId$: Observable<string> = this.route.queryParamMap.pipe(
-    map((params) => params.get('id'))
-  );
-  private recipe$: Observable<Recipe> = this.recipeId$.pipe(
-    switchMap((recipeId) => this.recipeService.getRecipeByRecipeId(recipeId))
+  private recipeId: string;
+  private recipe$: Observable<Recipe> = this.route.queryParamMap.pipe(
+    switchMap((params) => {
+      this.recipeId = params.get('id');
+      return this.recipeService.getRecipeByRecipeId(this.recipeId);
+    })
   );
 
   readonly maxTitleLength = 50;
@@ -53,7 +54,6 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
   readonly minNutritionAmount = 0;
   thumbnailURL: string = null;
   processURLs = [];
-  query: string;
   ingredient = false;
   process = false;
   public = false;
@@ -269,7 +269,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
         data: {
           imageFile,
           thumbnailURL: this.thumbnailURL,
-          recipeId: this.query,
+          recipeId: this.recipeId,
         },
       });
 
@@ -288,7 +288,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
         data: {
           imageFile,
           processImageURL: this.processURLs[index],
-          recipeId: this.query,
+          recipeId: this.recipeId,
         },
       });
 
@@ -336,9 +336,9 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
       foods: formData.ingredients,
       processes: sendProcesses,
     };
-    if (this.query) {
+    if (this.recipeId) {
       this.recipeService.updateRecipe({
-        recipeId: this.query,
+        recipeId: this.recipeId,
         ...recipeDataExcludeRecipeId,
       });
     } else {
@@ -350,7 +350,7 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
   }
 
   deleteImage() {
-    this.recipeService.deleteUpdatedImage(this.userId, this.query);
+    this.recipeService.deleteUpdatedImage(this.userId, this.recipeId);
   }
 
   @HostListener('window:beforeunload', ['$event'])

--- a/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
+++ b/src/app/menu/recipe/recipe-editor/recipe-editor.component.ts
@@ -154,10 +154,10 @@ export class RecipeEditorComponent implements OnInit, OnDestroy {
     private recipeService: RecipeService,
     private authService: AuthService
   ) {
-    this.getRecipe();
+    this.setRecipeForm();
   }
 
-  private getRecipe() {
+  private setRecipeForm() {
     const recipeSub = this.route.queryParamMap.subscribe((recipeId) => {
       if (recipeId.get('id')) {
         this.query = recipeId.get('id');

--- a/src/app/menu/recipe/recipe.component.html
+++ b/src/app/menu/recipe/recipe.component.html
@@ -51,7 +51,7 @@
     </div>
   </div>
   <div class="more-button" *ngIf="isMyRecipeNext">
-    <button mat-flat-button color="primary" (click)="getMyRecipes()">
+    <button mat-flat-button color="primary" (click)="loadMyRecipes()">
       もっと見る
     </button>
   </div>
@@ -101,7 +101,7 @@
       mat-flat-button
       type="button"
       color="primary"
-      (click)="getPublicRecipes()"
+      (click)="loadPublicRecipes()"
     >
       もっと見る
     </button>

--- a/src/app/menu/recipe/recipe.component.ts
+++ b/src/app/menu/recipe/recipe.component.ts
@@ -13,12 +13,12 @@ import { take } from 'rxjs/operators';
 })
 export class RecipeComponent implements OnInit {
   private readonly userId = this.authService.uid;
-  private readonly getNumber = 10;
+  private readonly perDocNum = 10;
   private lastMyRecipeDoc: QueryDocumentSnapshot<Recipe>;
   private lastPublicRecipeDoc: QueryDocumentSnapshot<Recipe>;
 
-  myRecipeloading: boolean;
-  publicRecipeloading: boolean;
+  myRecipeloading = true;
+  publicRecipeloading = true;
   myRecipes: RecipeWithAuthor[] = new Array();
   publicRecipes: RecipeWithAuthor[] = new Array();
   isMyRecipeNext: boolean;
@@ -27,15 +27,11 @@ export class RecipeComponent implements OnInit {
   constructor(
     private recipeService: RecipeService,
     private authService: AuthService
-  ) {
-    this.getMyRecipes();
-    this.getPublicRecipes();
-  }
+  ) {}
 
-  getMyRecipes() {
-    this.myRecipeloading = true;
+  loadMyRecipes(): void {
     this.recipeService
-      .getMyRecipes(this.userId, this.getNumber, this.lastMyRecipeDoc)
+      .getMyRecipes(this.userId, this.perDocNum, this.lastMyRecipeDoc)
       .pipe(take(1))
       .subscribe(
         (doc: {
@@ -47,7 +43,7 @@ export class RecipeComponent implements OnInit {
             if (doc.data && doc.data.length > 0) {
               doc.data.forEach((recipe: RecipeWithAuthor) => {
                 this.myRecipes.push(recipe);
-                if (doc.data.length >= this.getNumber) {
+                if (doc.data.length >= this.perDocNum) {
                   this.isMyRecipeNext = true;
                 } else {
                   this.isMyRecipeNext = false;
@@ -62,10 +58,10 @@ export class RecipeComponent implements OnInit {
       );
   }
 
-  getPublicRecipes() {
+  loadPublicRecipes(): void {
     this.publicRecipeloading = true;
     this.recipeService
-      .getPublicRecipes(this.getNumber, this.lastPublicRecipeDoc)
+      .getPublicRecipes(this.perDocNum, this.lastPublicRecipeDoc)
       .pipe(take(1))
       .subscribe(
         (doc: {
@@ -77,7 +73,7 @@ export class RecipeComponent implements OnInit {
             if (doc.data && doc.data.length > 0) {
               doc.data.forEach((recipe: RecipeWithAuthor) => {
                 this.publicRecipes.push(recipe);
-                if (doc.data.length >= this.getNumber) {
+                if (doc.data.length >= this.perDocNum) {
                   this.isPublicRecipeNext = true;
                 }
               });
@@ -90,5 +86,8 @@ export class RecipeComponent implements OnInit {
       );
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.loadMyRecipes();
+    this.loadPublicRecipes();
+  }
 }

--- a/src/app/menu/recipe/recipe.component.ts
+++ b/src/app/menu/recipe/recipe.component.ts
@@ -59,7 +59,6 @@ export class RecipeComponent implements OnInit {
   }
 
   loadPublicRecipes(): void {
-    this.publicRecipeloading = true;
     this.recipeService
       .getPublicRecipes(this.perDocNum, this.lastPublicRecipeDoc)
       .pipe(take(1))

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -219,7 +219,11 @@ export class RecipeService {
     return imageURL;
   }
 
-  async uploadProcessImage(userId: string, recipeId: string, file: Blob) {
+  async uploadProcessImage(
+    userId: string,
+    recipeId: string,
+    file: Blob
+  ): Promise<string> {
     const imageId = this.db.createId();
     const result = await this.storage
       .ref(`users/${userId}/recipes/${recipeId}/processImages/${imageId}`)

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -31,7 +31,7 @@ export class RecipeService {
 
   getMyRecipes(
     userId: string,
-    getNumber: number,
+    perDocNum: number,
     lastDoc?: QueryDocumentSnapshot<Recipe>
   ): Observable<{
     data: RecipeWithAuthor[];
@@ -42,9 +42,9 @@ export class RecipeService {
         let query = ref
           .where('authorId', '==', userId)
           .orderBy('updatedAt', 'desc')
-          .limit(getNumber);
+          .limit(perDocNum);
         if (lastDoc) {
-          query = query.startAfter(lastDoc).limit(getNumber);
+          query = query.startAfter(lastDoc).limit(perDocNum);
         }
         return query;
       })
@@ -71,7 +71,7 @@ export class RecipeService {
         data: RecipeWithAuthor[];
         nextLastDoc: QueryDocumentSnapshot<Recipe>;
       } => {
-        if (recipes && recipes.length > 0 && basicInfo) {
+        if (recipes?.length > 0 && basicInfo) {
           const recipeswithAuthor: RecipeWithAuthor[] = recipes.map(
             (recipe: Recipe) => {
               return {
@@ -80,7 +80,6 @@ export class RecipeService {
               };
             }
           );
-
           return {
             data: recipeswithAuthor,
             nextLastDoc,

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -12,7 +12,6 @@ import { Router } from '@angular/router';
 import { Observable, combineLatest, of } from 'rxjs';
 import { switchMap, map } from 'rxjs/operators';
 import { RecipeWithAuthor } from '../interfaces/recipe';
-import { Location } from '@angular/common';
 import { AngularFireFunctions } from '@angular/fire/functions';
 import { BasicInfoService } from './basic-info.service';
 import { BasicInfo } from '../interfaces/basic-info';
@@ -26,7 +25,6 @@ export class RecipeService {
     public storage: AngularFireStorage,
     private snackBar: MatSnackBar,
     private router: Router,
-    private location: Location,
     private fns: AngularFireFunctions,
     private basicInfoService: BasicInfoService
   ) {}

--- a/src/app/services/recipe.service.ts
+++ b/src/app/services/recipe.service.ts
@@ -184,7 +184,6 @@ export class RecipeService {
         this.snackBar.open('レシピを作成しました', null, {
           duration: 2000,
         });
-        this.location.back();
       });
   }
 
@@ -193,12 +192,10 @@ export class RecipeService {
     return this.db
       .doc<Recipe>(`recipes/${recipe.recipeId}`)
       .update({ ...recipe, updatedAt })
-
       .then(() => {
         this.snackBar.open('レシピを更新しました', null, {
           duration: 2000,
         });
-        this.location.back();
       });
   }
 


### PR DESCRIPTION
以下の改善を行いました。ご確認お願いします。

## Detail

### list
- [x] 関数名リファクタ,返り値設定

### editor
- [x] submit関数でcreate,updateオブジェクトの重複を解消
- [x] 関数名リファクタ,返り値設定
- [x] ２重observableをswitchMap使い解消

### detail
- [x] 三項演算子を ||で可能なところは修正
- [x] ２重observableをswitchMap使い解消

### service
- [x] getPublicRecipesリファクタ
- [x] getMyRecipesリファクタ
- [x] レシピの更新関数からページ遷移機能消す

**serviceの`deleteRecipe()`のページ遷移は#193**