### PR TITLE
食事ページ、メニューページ間queryParams整理 #187

### DIFF
--- a/src/app/editor-meal/editor-meal/editor-meal.component.html
+++ b/src/app/editor-meal/editor-meal/editor-meal.component.html
@@ -10,7 +10,7 @@
         class="mat-tab-label-meal"
         mat-tab-link
         routerLink="search"
-        [queryParams]="{ date: date, meal: meal }"
+        [queryParams]="linkQuery"
         routerLinkActive
         #rla0="routerLinkActive"
         [active]="rla0.isActive"
@@ -21,7 +21,7 @@
         class="mat-tab-label-meal"
         mat-tab-link
         routerLink="fav-foods"
-        [queryParams]="{ date: date, meal: meal }"
+        [queryParams]="linkQuery"
         routerLinkActive
         #rla1="routerLinkActive"
         [active]="rla1.isActive"
@@ -32,7 +32,7 @@
         class="mat-tab-label-meal"
         mat-tab-link
         routerLink="my-set"
-        [queryParams]="{ date: date, meal: meal }"
+        [queryParams]="linkQuery"
         routerLinkActive
         #rla2="routerLinkActive"
         [active]="rla2.isActive"
@@ -43,7 +43,7 @@
         class="mat-tab-label-meal mat-tab-label-meal--selected"
         mat-tab-link
         routerLink="selected-foods"
-        [queryParams]="{ date: date, meal: meal }"
+        [queryParams]="linkQuery"
         routerLinkActive
         #rla3="routerLinkActive"
         [active]="rla3.isActive"

--- a/src/app/editor-meal/my-set/my-set.component.ts
+++ b/src/app/editor-meal/my-set/my-set.component.ts
@@ -128,7 +128,7 @@ export class MySetComponent implements OnInit, OnDestroy {
 
   goToSetPage() {
     this.dailyInfoService.goToSetPage(this.date, this.meal);
-    this.setService.addingDailyInfo();
+    this.setService.changeEditingDailyInfo();
   }
 
   openBottomSheet(set: Set): void {

--- a/src/app/menu/menu/menu.component.html
+++ b/src/app/menu/menu/menu.component.html
@@ -1,19 +1,15 @@
 <a
-  *ngIf="dailyInfoService.editorMealPageQueryParams"
+  *ngIf="mealPageQueryParams"
   mat-stroked-button
   routerLink="/editor-meal/my-set"
   [queryParams]="{
-    date: dailyInfoService.editorMealPageQueryParams.date,
-    meal: dailyInfoService.editorMealPageQueryParams.meal
+    date: mealPageQueryParams.date,
+    meal: mealPageQueryParams.meal
   }"
   class="meal-nav"
 >
   <mat-icon>navigate_before</mat-icon>
-  <span
-    >{{
-      mealCategory[dailyInfoService.editorMealPageQueryParams.meal]
-    }}登録へ戻る</span
-  >
+  <span>{{ mealCategory[mealPageQueryParams.meal] }}登録へ戻る</span>
 </a>
 
 <div class="tabs">

--- a/src/app/menu/menu/menu.component.html
+++ b/src/app/menu/menu/menu.component.html
@@ -1,14 +1,20 @@
-<button
-  *ngIf="queryParams"
+<a
+  *ngIf="dailyInfoService.editorMealPageQueryParams"
   mat-stroked-button
-  (click)="backToMeal()"
+  routerLink="/editor-meal/my-set"
+  [queryParams]="{
+    date: dailyInfoService.editorMealPageQueryParams.date,
+    meal: dailyInfoService.editorMealPageQueryParams.meal
+  }"
   class="meal-nav"
 >
   <mat-icon>navigate_before</mat-icon>
-  <span *ngIf="queryParams[1] === 'breakfast'">朝食登録へ戻る</span>
-  <span *ngIf="queryParams[1] === 'lunch'">昼食登録へ戻る</span>
-  <span *ngIf="queryParams[1] === 'dinner'">夕食登録へ戻る</span>
-</button>
+  <span
+    >{{
+      mealCategory[dailyInfoService.editorMealPageQueryParams.meal]
+    }}登録へ戻る</span
+  >
+</a>
 
 <div class="tabs">
   <nav

--- a/src/app/menu/menu/menu.component.ts
+++ b/src/app/menu/menu/menu.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MainShellService } from 'src/app/services/main-shell.service';
 import { DailyInfoService } from 'src/app/services/daily-info.service';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-menu',
@@ -9,23 +8,17 @@ import { Router } from '@angular/router';
   styleUrls: ['./menu.component.scss'],
 })
 export class MenuComponent implements OnInit {
-  queryParams = this.dailyInfoService.queryParams;
+  readonly mealCategory = {
+    breakfast: '朝食',
+    lunch: '昼食',
+    dinner: '夕食',
+  };
   constructor(
-    private router: Router,
-    private dailyInfoService: DailyInfoService,
+    public dailyInfoService: DailyInfoService,
     private mainShellService: MainShellService
-  ) {
+  ) {}
+
+  ngOnInit(): void {
     this.mainShellService.title = this.mainShellService.PAGE_TITLES.menu;
   }
-
-  backToMeal() {
-    this.router.navigate(['/editor-meal/my-set'], {
-      queryParams: {
-        date: this.queryParams[0],
-        meal: this.queryParams[1],
-      },
-    });
-  }
-
-  ngOnInit(): void {}
 }

--- a/src/app/menu/menu/menu.component.ts
+++ b/src/app/menu/menu/menu.component.ts
@@ -1,13 +1,16 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MainShellService } from 'src/app/services/main-shell.service';
 import { DailyInfoService } from 'src/app/services/daily-info.service';
+import { SetService } from 'src/app/services/set.service';
 
 @Component({
   selector: 'app-menu',
   templateUrl: './menu.component.html',
   styleUrls: ['./menu.component.scss'],
 })
-export class MenuComponent implements OnInit {
+export class MenuComponent implements OnInit, OnDestroy {
+  readonly mealPageQueryParams = this.dailyInfoService
+    .editorMealPageQueryParams;
   readonly mealCategory = {
     breakfast: '朝食',
     lunch: '昼食',
@@ -15,10 +18,17 @@ export class MenuComponent implements OnInit {
   };
   constructor(
     public dailyInfoService: DailyInfoService,
-    private mainShellService: MainShellService
+    private mainShellService: MainShellService,
+    private setService: SetService
   ) {}
 
   ngOnInit(): void {
     this.mainShellService.title = this.mainShellService.PAGE_TITLES.menu;
+  }
+
+  ngOnDestroy(): void {
+    if (!this.setService.isEditingEditorMeal && this.mealPageQueryParams) {
+      this.dailyInfoService.editorMealPageQueryParams = null;
+    }
   }
 }

--- a/src/app/menu/menu/menu.component.ts
+++ b/src/app/menu/menu/menu.component.ts
@@ -2,6 +2,9 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MainShellService } from 'src/app/services/main-shell.service';
 import { DailyInfoService } from 'src/app/services/daily-info.service';
 import { SetService } from 'src/app/services/set.service';
+import { Location } from '@angular/common';
+import { Event, NavigationEnd, Router } from '@angular/router';
+import { filter, take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-menu',
@@ -19,7 +22,9 @@ export class MenuComponent implements OnInit, OnDestroy {
   constructor(
     public dailyInfoService: DailyInfoService,
     private mainShellService: MainShellService,
-    private setService: SetService
+    private setService: SetService,
+    private location: Location,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -27,8 +32,25 @@ export class MenuComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    if (!this.setService.isEditingEditorMeal && this.mealPageQueryParams) {
-      this.dailyInfoService.editorMealPageQueryParams = null;
-    }
+    this.deleteEditorMealPageParams();
+  }
+
+  private deleteEditorMealPageParams(): void {
+    this.router.events
+      .pipe(
+        filter((e: Event): e is NavigationEnd => e instanceof NavigationEnd),
+        take(1)
+      )
+      .subscribe((e: NavigationEnd) => {
+        const nextURL = e.url;
+        if (
+          !this.setService.isEditingEditorMeal &&
+          this.mealPageQueryParams &&
+          nextURL !== '/set-editor' &&
+          nextURL !== '/recipe-editor'
+        ) {
+          this.dailyInfoService.editorMealPageQueryParams = null;
+        }
+      });
   }
 }

--- a/src/app/menu/menu/menu.component.ts
+++ b/src/app/menu/menu/menu.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MainShellService } from 'src/app/services/main-shell.service';
 import { DailyInfoService } from 'src/app/services/daily-info.service';
 import { SetService } from 'src/app/services/set.service';
-import { Location } from '@angular/common';
 import { Event, NavigationEnd, Router } from '@angular/router';
 import { filter, take } from 'rxjs/operators';
 
@@ -23,7 +22,6 @@ export class MenuComponent implements OnInit, OnDestroy {
     public dailyInfoService: DailyInfoService,
     private mainShellService: MainShellService,
     private setService: SetService,
-    private location: Location,
     private router: Router
   ) {}
 

--- a/src/app/menu/set/set-editor/set-editor.component.ts
+++ b/src/app/menu/set/set-editor/set-editor.component.ts
@@ -384,7 +384,7 @@ export class SetEditorComponent implements OnInit {
       });
     }
     this.location.back();
-    this.setService.addingDailyInfo();
+    this.setService.changeEditingDailyInfo();
   }
 
   openRecipeDialog(recipeId: string): void {
@@ -403,7 +403,7 @@ export class SetEditorComponent implements OnInit {
   }
 
   backToMenuPage(): void {
-    this.setService.addingDailyInfo();
+    this.setService.changeEditingDailyInfo();
     this.location.back();
   }
 }

--- a/src/app/menu/set/set.component.ts
+++ b/src/app/menu/set/set.component.ts
@@ -13,8 +13,9 @@ import { DailyInfoService } from 'src/app/services/daily-info.service';
   styleUrls: ['./set.component.scss'],
 })
 export class SetComponent implements OnInit {
-  private readonly queryParams = this.dailyInfoService.queryParams;
-  private readonly querySetParam = this.setService.querySetParam;
+  private readonly editorMealPageQueryParams = this.dailyInfoService
+    .editorMealPageQueryParams;
+  private readonly isQuerySetParam = this.setService.isEditingEditorMeal;
   private readonly perDocNum = 10;
   private readonly userId: string = this.authService.uid;
   private lastDoc: QueryDocumentSnapshot<Set>;
@@ -48,7 +49,7 @@ export class SetComponent implements OnInit {
             this.isNext = true;
           }
         } else {
-          if (this.queryParams && this.querySetParam) {
+          if (this.editorMealPageQueryParams && this.isQuerySetParam) {
             this.router.navigateByUrl('/set-editor');
           }
           this.isNext = false;

--- a/src/app/services/daily-info.service.ts
+++ b/src/app/services/daily-info.service.ts
@@ -19,7 +19,7 @@ export class DailyInfoService {
   whichMeal: string;
   meal: string;
   date: string;
-  queryParams: string[];
+  editorMealPageQueryParams: { date: string; meal: string };
   constructor(
     private db: AngularFirestore,
     private snackBar: MatSnackBar,
@@ -43,7 +43,7 @@ export class DailyInfoService {
   }
 
   goToSetPage(date: string, meal: string) {
-    this.queryParams = [date, meal];
+    this.editorMealPageQueryParams = { date, meal };
     this.router.navigateByUrl('/menu/set-list');
   }
 

--- a/src/app/services/set.service.ts
+++ b/src/app/services/set.service.ts
@@ -15,12 +15,12 @@ import { switchMap, map } from 'rxjs/operators';
 })
 export class SetService {
   submitted: boolean;
-  querySetParam: boolean;
+  isEditingEditorMeal: boolean;
 
   constructor(private db: AngularFirestore, private snackBar: MatSnackBar) {}
 
-  addingDailyInfo(): boolean {
-    return (this.querySetParam = this.querySetParam ? false : true);
+  changeEditingDailyInfo(): boolean {
+    return (this.isEditingEditorMeal = this.isEditingEditorMeal ? false : true);
   }
 
   getSets(

--- a/src/app/toolbar/toolbar.component.html
+++ b/src/app/toolbar/toolbar.component.html
@@ -28,12 +28,7 @@
         <span>{{ mainShellService.PAGE_TITLES.graph }}</span>
       </div>
     </a>
-    <a
-      mat-button
-      class="nav"
-      routerLink="/menu/set-list"
-      (click)="changeQuery()"
-    >
+    <a mat-button class="nav" routerLink="/menu/set-list">
       <mat-icon
         [fontSet]="
           mainShellService.title === mainShellService.PAGE_TITLES.menu

--- a/src/app/toolbar/toolbar.component.ts
+++ b/src/app/toolbar/toolbar.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { DailyInfoService } from '../services/daily-info.service';
 import { MainShellService } from '../services/main-shell.service';
 
 @Component({
@@ -8,14 +7,7 @@ import { MainShellService } from '../services/main-shell.service';
   styleUrls: ['./toolbar.component.scss'],
 })
 export class ToolbarComponent implements OnInit {
-  constructor(
-    private dailyInfoService: DailyInfoService,
-    public mainShellService: MainShellService
-  ) {}
-
-  changeQuery() {
-    this.dailyInfoService.queryParams = null;
-  }
+  constructor(public mainShellService: MainShellService) {}
 
   ngOnInit(): void {}
 }


### PR DESCRIPTION
fix #187 
以下の機能を実装しました。ご確認お願いします。

## Detail
- [x] 食事登録ページとメニューページ間のページ遷移で使用するqueryParamsオブジェクトで管理
- [x] メニューページから離れた時のみ食事クエリ削除する